### PR TITLE
Homeassistant ADdon doesn't start

### DIFF
--- a/docker/releaseAddon.py
+++ b/docker/releaseAddon.py
@@ -41,8 +41,12 @@ def createAddonDirectoryForRelease(basedir,version):
     sys.stderr.write("createAddonDirectory release " + basedir  + " " +  version)
     replaceStringInFile(os.path.join(basedir, server, 'hassio-addon', configYaml), \
         os.path.join(basedir, hassioAddonRepository,modbus2mqtt,  configYaml),"<version>", version )
+
     tar = tarfile.open(os.path.join(basedir, hassioAddonRepository,modbus2mqtt,"rootfs.tar"), "w")
-    tar.add(os.path.join(basedir, server,dockerDir, "rootfs"))
+    pwd = os.getcwd()
+    os.chdir(os.path.join(basedir, server,dockerDir, "rootfs"))
+    tar.add('.')
+    os.chdir(pwd)
     tar.close()
 
 def createAddonDirectoryForDebug(basedir):


### PR DESCRIPTION
The s6-overlay directory was empty, because the rootfs.tar file contained absolute pathes
Now, it use relative pathes