### PR TITLE
Working version of release.py

### DIFF
--- a/docker/cp.sh
+++ b/docker/cp.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-CONTAINER=$(docker container ps | grep modbus2mqtt| awk '{print $1}')
+CONTAINER=$(docker container ps | grep modbuslocal| awk '{print $1}')
 echo Container: $CONTAINER
 if [ "$CONTAINER" = "" ] 
 then


### PR DESCRIPTION
Release.py need this file structure:
clone modbus2mqtt/specification.shared
clone modbus2mqtt/server.shared
clone modbus2mqtt/specification
clone modbus2mqtt/angular
clone modbus2mqtt/server
clone modbus2mqtt/hassio-addon-repository 
into  the same root directory.

release.py has a debug mode. It copies the addon to a local directory on a HA server
It restarts the addon and waits for attaching the debugger at 9229
You can call it multiple times. It will only update the modbus/* components from the local directory and copy it into the addon docker container and then restart the node process.
This is a quick way. to test the addon in a HA environment.

release.ps w/o debug will check the components
After successful check, it will add a release tag.
This triggers the CI/CD workflow to release the component.

