### PR TITLE
Fixes for Validation, Contribution and Specification Detection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,8 +37,14 @@
       "type": "node-terminal",
       "env": {
         "DEBUG": "m2mgithub",
-        "MODBUS2MQTT_NOPOLL": "",
-      }
+        "MODBUS_NOPOLL": "true",
+      },
+      "sourceMapPathOverrides": {
+        "server/*/*": "${workspaceFolder}/*",
+        "specification.shared/*/*": "${workspaceFolder}../specification.shared/*/*",
+        "server.shared/*/*": "${workspaceFolder}../server.shared/*/*",
+        "specification/*/*": "${workspaceFolder}../specification/*/*",
+      },
     },
     {
       "command": "npm run modbusanalysis",
@@ -52,9 +58,15 @@
       "request": "launch",
       "type": "node-terminal",
       "env": {
-        "DEBUG": "express:* modbuscache modbuscache.time",
-        "MODBUS2MQTT_NOPOLL": "",
-      }
+        "DEBUGX": "express:* modbuscache modbuscache.time",
+        "MODBUS_NOPOLL": "true",
+      },
+      "sourceMapPathOverrides": {
+        "server/*/*": "${workspaceFolder}/*",
+        "specification.shared/*/*": "${workspaceFolder}../specification.shared/*/*",
+        "server.shared/*/*": "${workspaceFolder}../server.shared/*/*",
+        "specification/*/*": "${workspaceFolder}../specification/*/*",
+      },
     },
     {
       "command": "npm run serverTCP",
@@ -64,7 +76,7 @@
       "type": "node-terminal",
       "env": {
         "DEBUG": "express:* modbuscache modbuscache.time",
-        "MODBUS2MQTT_NOPOLL": "",
+        "MODBUS2_NOPOLL": "",
       }
     },
     {
@@ -76,7 +88,6 @@
       "env": {
         "DEBUG": "m2mgithubvalidate",
         "PR_NUMBER": "62",
-        "GITHUB_TOKEN": "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"
       }
     },
     {
@@ -86,7 +97,7 @@
       "type": "node-terminal",
       "env": {
         "DEBUG": "express:* modbuscache modbuscache.time",
-        "MODBUS2MQTT_NOPOLL": "",
+        "MODBUS2_NOPOLL": "",
       },
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,7 +58,7 @@
       "request": "launch",
       "type": "node-terminal",
       "env": {
-        "DEBUGX": "express:* modbuscache modbuscache.time",
+        "DEBUG": "httpserver",
         "MODBUS_NOPOLL": "true",
       },
       "sourceMaps": true,
@@ -66,7 +66,7 @@
         "server/*/*": "${workspaceFolder}/*",
         "specification.shared/*/*": "${workspaceFolder}/../specification.shared/*",
         "server.shared/*/*": "${workspaceFolder}/../server.shared/*",
-        "specification/*/*": "${workspaceFolder}/../specification/*",
+        "specification/*/*": "${workspaceFolder}/../specification/src/*",
       },
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,11 +61,12 @@
         "DEBUGX": "express:* modbuscache modbuscache.time",
         "MODBUS_NOPOLL": "true",
       },
+      "sourceMaps": true,
       "sourceMapPathOverrides": {
         "server/*/*": "${workspaceFolder}/*",
-        "specification.shared/*/*": "${workspaceFolder}../specification.shared/*/*",
-        "server.shared/*/*": "${workspaceFolder}../server.shared/*/*",
-        "specification/*/*": "${workspaceFolder}../specification/*/*",
+        "specification.shared/*/*": "${workspaceFolder}/../specification.shared/*",
+        "server.shared/*/*": "${workspaceFolder}/../server.shared/*",
+        "specification/*/*": "${workspaceFolder}/../specification/*",
       },
     },
     {

--- a/__tests__/httpserver_test.tsx
+++ b/__tests__/httpserver_test.tsx
@@ -405,7 +405,7 @@ describe('http POST', () => {
         .post(url)
         .accept('application/json')
         .send(spec1)
-        .expect(HttpErrorsEnum.ErrBadRequest)
+        .expect(HttpErrorsEnum.OkCreated)
         .catch((e) => {
           log.log(LogLevelEnum.error, JSON.stringify(e))
           expect(1).toBeFalsy()
@@ -427,8 +427,6 @@ describe('http POST', () => {
             .then((response) => {
               var found = ConfigSpecification.getSpecificationByFilename(spec1.filename)!
               let newFilename = new ConfigSpecification().getSpecificationPath(response.body)
-              let foundData = found.testdata.holdingRegisters?.find((data) => data.address == 100 && !data.value)
-              expect(foundData).toBeDefined()
               expect(fs.existsSync(newFilename)).toBeTruthy()
               expect(getSpecificationI18nName(found!, 'en')).toBe('Water Level Transmitter')
               expect(response)

--- a/__tests__/modbuscache_test.tsx
+++ b/__tests__/modbuscache_test.tsx
@@ -169,8 +169,10 @@ describe('submitGetHoldingRegisterRequests', () => {
         address: 4,
         registerType: ModbusRegisterType.HoldingRegister,
       })
-      let f = (_addresses: Set<ImodbusAddress>, _results: ImodbusValues) => {
+      let f = (_addresses: Set<ImodbusAddress>, results: ImodbusValues) => {
         expect(readHoldingRegisters).toHaveBeenCalledTimes(4)
+        expect(results.holdingRegisters.get(4)!.error).not.toBeDefined()
+        expect(results.holdingRegisters.get(5)!.error).not.toBeDefined()
         mockMutex.release()
         done()
       }
@@ -191,6 +193,7 @@ describe('submitGetHoldingRegisterRequests', () => {
       })
       let f = (_addresses: Set<ImodbusAddress>, results: ImodbusValues) => {
         expectObjectToBe(results.holdingRegisters.get(10), getReadRegisterResult(10))
+        expect(results.holdingRegisters.get(4)!.error).not.toBeDefined()
         expect(readHoldingRegisters).toHaveBeenCalledTimes(12)
         mockMutex.release()
         done()

--- a/__tests__/modbuscache_test.tsx
+++ b/__tests__/modbuscache_test.tsx
@@ -109,6 +109,7 @@ function resultFunction1(addresses: Set<ImodbusAddress>, results: ImodbusValues)
 function resultFunction0Illegal(addresses: Set<ImodbusAddress>, results: ImodbusValues): void {
   expect(results.holdingRegisters.get(4)).toBeDefined()
   expect(results.holdingRegisters.get(4)!.result!.data[0]).toBe(4)
+  expect(results.holdingRegisters.get(3)!.error).toBeDefined()
   let na = structuredClone(addresses)
   na.add({ address: 10, registerType: ModbusRegisterType.HoldingRegister })
   submitReadRequest(na, resultFunctions[1])

--- a/__tests__/yaml-dir/local/specifications/waterleveltransmitter.yaml
+++ b/__tests__/yaml-dir/local/specifications/waterleveltransmitter.yaml
@@ -31,7 +31,4 @@ i18n:
       - textId: e1
         text: Water Level Transmitter
 version: "0.3"
-testdata:
-  holdingRegisters:
-    - address: 100
-      error: failed!!!
+testdata: {}

--- a/docker/releaseAddon.py
+++ b/docker/releaseAddon.py
@@ -38,7 +38,7 @@ def reset(tarinfo):
 # runs in (@modbus2mqtt)/server
 # updates config.yaml in (@modbus2mqtt)/hassio-addon-repository
 def createAddonDirectoryForRelease(basedir,version):
-    sys.stderr.write("createAddonDirectory release " + basedir  + " " +  version)
+    sys.stderr.write("createAddonDirectory release " + basedir  + " " +  version + "\n")
     replaceStringInFile(os.path.join(basedir, server, 'hassio-addon', configYaml), \
         os.path.join(basedir, hassioAddonRepository,modbus2mqtt,  configYaml),"<version>", version )
 

--- a/hassio-addon/config.yaml
+++ b/hassio-addon/config.yaml
@@ -1,7 +1,7 @@
 name: 'Modbus <=> MQTT'
 description: 'Service converts RTU and TCP Modbus to MQTT from other'
 version: <version>
-url: https://github.com/modbus2mqtt/hassio-addon
+url: https://github.com/modbus2mqtt/server/blob/main/introduction.md
 webui: http://[HOST]:[PORT:3000]
 panel_icon: mdi:arrow-left-right-bold-outline
 slug: 'modbus2mqtt'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "serverTCP": "npm run build.dev && node dist/modbus2mqtt.js -s ../ssl -y ../yaml-dir --busid 0",
     "build": "tsc && npx  @opengovsg/credits-generator",
     "build.docker": "docker buildx build --load --tag modbus2mqtt/server docker",
-    "ng serve": "cd ../angular && ng serve",
+    "ng serve": "cd ../angular && ng serve --open",
     "prettier": "prettier --write '**/*.{ts,js,css,html,tsx}'"
   },
   "dependencies": {

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -317,12 +317,12 @@ export class Bus {
           this.modbusClient!.readInputRegisters(dataaddress, length)
             .then((data) => {
               this.modbusClientActionMutex.release()
+              this.clearModbusTimout()
               let rc: ReadRegisterResultWithDuration = {
                 result: data,
                 duration: Date.now() - start,
               }
               resolve(rc)
-              this.clearModbusTimout()
             })
             .catch((e) => {
               this.modbusClientActionMutex.release()
@@ -345,6 +345,7 @@ export class Bus {
           this.modbusClient!.readDiscreteInputs(dataaddress, length)
             .then((resolveBoolean) => {
               this.modbusClientActionMutex.release()
+              this.clearModbusTimout()
               let readResult: ReadRegisterResult = {
                 data: [],
                 buffer: Buffer.allocUnsafe(0),
@@ -357,7 +358,6 @@ export class Bus {
                 duration: Date.now() - start,
               }
               resolve(rc)
-              this.clearModbusTimout()
             })
             .catch((e) => {
               this.modbusClientActionMutex.release()

--- a/src/httpserver.ts
+++ b/src/httpserver.ts
@@ -439,21 +439,6 @@ export class HttpServer extends HttpServerBase {
       let bus: Bus | undefined
       let slave: Islave | undefined
       let busId: number | undefined
-      let testdata: ImodbusValues | undefined
-      if ((req.query.busid, req.query.slaveid)) {
-        busId = Number.parseInt(req.query.busid)
-        let slaveId = Number.parseInt(req.query.slaveid)
-        bus = Bus.getBus(busId)
-        if (bus !== undefined) {
-          slave = bus.getSlaveBySlaveId(slaveId)
-          let slaveAddresses = bus.getModbusAddressesForSlave(slaveId)
-          if (slaveAddresses) testdata = M2mSpecification.getEmptyModbusAddressesFromSlaveToTestdata(slaveAddresses)
-        }
-      }
-      if (testdata == undefined) {
-        this.returnResult(req, res, HttpErrorsEnum.ErrBadRequest, JSON.stringify('No extended testdata available, try again later'))
-        return
-      }
       if (msg !== '') {
         this.returnResult(req, res, HttpErrorsEnum.ErrBadRequest, "{message: '" + msg + "'}")
         return
@@ -461,7 +446,6 @@ export class HttpServer extends HttpServerBase {
       let originalFilename: string | null = req.query.originalFilename ? req.query.originalFilename : null
       var rc = rd.writeSpecification(
         req.body,
-        testdata,
         (filename: string) => {
           if (busId != undefined && bus != undefined && slave != undefined) {
             slave.specificationid = filename

--- a/src/httpserver.ts
+++ b/src/httpserver.ts
@@ -291,7 +291,9 @@ export class HttpServer extends HttpServerBase {
             // poll status updates of pull request
             client.startPolling((e) => {
               log.log(LogLevelEnum.error, e.message)
-            })
+            })?.subscribe(pullRequest=>{
+              log.log(LogLevelEnum.notice, "Merged " + pullRequest.pullNumber)
+            } )
             this.returnResult(req, res, HttpErrorsEnum.OkCreated, JSON.stringify(response))
           })
           .catch((err) => {

--- a/src/modbus.ts
+++ b/src/modbus.ts
@@ -107,7 +107,6 @@ export class Modbus {
     let mspec = M2mSpecification.fileToModbusSpecification(specification!, values)
     if (mspec) sub.next(mspec)
   }
-
   static getModbusSpecificationFromData(
     task: string,
     bus: Bus,
@@ -116,6 +115,7 @@ export class Modbus {
     sub: Subject<ImodbusSpecification>
   ): void {
     let addresses = new Set<ImodbusAddress>()
+    ConfigSpecification.clearModbusData(specification)
     let info = '(' + bus.getId() + ',' + slaveid + ')'
     Bus.getModbusAddressesForSpec(specification, addresses)
 

--- a/src/modbus2mqtt.ts
+++ b/src/modbus2mqtt.ts
@@ -109,6 +109,9 @@ export class Modbus2Mqtt {
               let md = Config.getMqttDiscover()
               md.startPolling()
             }
+            else{
+              log.log(LogLevelEnum.notice, "Poll disabled by environment variable MODBUS_POLL")
+            }
           })
         })
       })


### PR DESCRIPTION

Specification Detection: Don't use errors for detection of specifications.
Validation, Contribution: Remove modbusError and other attributes from IfileSpecification
Specification Detection: modus read: Split addresses when timeout occurs to read all remaining data.
