### PR TITLE
Fixes for MQTT discovery and minor UI changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@modbus2mqtt/server",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modbus2mqtt/server",
-      "version": "0.16.13",
+      "version": "0.16.14",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/translate": "^8.3.0",
-        "@modbus2mqtt/angular": "^0.12.10",
+        "@modbus2mqtt/angular": "^0.12.11",
         "@modbus2mqtt/server.shared": "^0.13.7",
-        "@modbus2mqtt/specification": "^0.15.20",
+        "@modbus2mqtt/specification": "^0.15.21",
         "@modbus2mqtt/specification.shared": "^0.10.6",
         "@octokit/rest": "^20.1.1",
         "adm-zip": "^0.5.16",
@@ -2528,9 +2528,9 @@
       }
     },
     "node_modules/@modbus2mqtt/angular": {
-      "version": "0.12.10",
-      "resolved": "https://registry.npmjs.org/@modbus2mqtt/angular/-/angular-0.12.10.tgz",
-      "integrity": "sha512-d69hN3/x5k3+QOxieTOjtnNv9iho0C6zQTUgHWK4DDMWL3o/Vv7f08yvdsZ4W49gXQeR3qvDkbIuV4SLFRY0vg==",
+      "version": "0.12.11",
+      "resolved": "https://registry.npmjs.org/@modbus2mqtt/angular/-/angular-0.12.11.tgz",
+      "integrity": "sha512-mFyuV7bO7lXjegOlFzyDvfdvV9RBiXkACxQmlq0y8rMKZYS27eVEdMFdo9mTnQ+dNWwPzJvICHAR1C7ZlQhoGw==",
       "dependencies": {
         "mat-icon-button-sizes": "^1.0.6"
       }
@@ -2546,9 +2546,9 @@
       }
     },
     "node_modules/@modbus2mqtt/specification": {
-      "version": "0.15.20",
-      "resolved": "https://registry.npmjs.org/@modbus2mqtt/specification/-/specification-0.15.20.tgz",
-      "integrity": "sha512-0GtztZ6ibDijmWPG/cEZ/sDUI8mTcKlyPQIX77QBUcpn+OY4oTCKKL90Cn8Ep5EKT9dg4TmeODo6PnmqKw3EqQ==",
+      "version": "0.15.21",
+      "resolved": "https://registry.npmjs.org/@modbus2mqtt/specification/-/specification-0.15.21.tgz",
+      "integrity": "sha512-XiqyNcpta1bBRbNQlD946rC7j41doFGkwvvXz527EBC3bT678kjmA+eup/dSMVSmZoRigSJd7/aMKXltqXEV0w==",
       "license": "MIT",
       "dependencies": {
         "@modbus2mqtt/specification.shared": "^0.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modbus2mqtt/server",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "sshserver": "homeassistant@homeassistant.lan",
   "homepage": "https://github.com/modbus2mqtt/server/README.md",
   "description": "server for modbus2mqtt for REST API of configuration and publishing modbus values to mqtt",
@@ -35,9 +35,9 @@
   },
   "dependencies": {
     "@google-cloud/translate": "^8.3.0",
-    "@modbus2mqtt/angular": "^0.12.10",
+    "@modbus2mqtt/angular": "^0.12.11",
     "@modbus2mqtt/server.shared": "^0.13.7",
-    "@modbus2mqtt/specification": "^0.15.20",
+    "@modbus2mqtt/specification": "^0.15.21",
     "@modbus2mqtt/specification.shared": "^0.10.6",
     "@octokit/rest": "^20.1.1",
     "adm-zip": "^0.5.16",

--- a/src/config.ts
+++ b/src/config.ts
@@ -670,8 +670,8 @@ export class Config {
     return Config.mqttDiscoverInstance
   }
 
-  triggerMqttPublishSlave(busid: number, slave: Islave) {
-    Config.getMqttDiscover().triggerPoll(busid, slave)
+  private triggerMqttPublishSlave(busid: number, slave: Islave) {
+    Config.getMqttDiscover().triggerPoll(busid, slave,true)
   }
 
   deleteSlave(busid: number, slaveid: number) {
@@ -774,9 +774,9 @@ export class Config {
       if (specification == '_new') new ConfigSpecification().deleteNewSpecificationFiles()
       else {
         let spec = ConfigSpecification.getSpecificationByFilename(specification)
-        this.triggerMqttPublishSlave(busid, slave)
         slave.specification = spec as any as IbaseSpecification
       }
+      this.triggerMqttPublishSlave(busid, slave)
     } else debug('No Specification found for slave: ' + filename + ' specification: ' + slave.specificationid)
     return slave
   }

--- a/src/httpserver.ts
+++ b/src/httpserver.ts
@@ -516,20 +516,20 @@ export class HttpServer extends HttpServerBase {
       debug('POST /specification: ' + req.query.busid + '/' + req.query.slaveid)
       let rd = new ConfigSpecification()
       let msg = this.checkBusidSlaveidParameter(req)
-      let bus: Bus | undefined
-      let slave: Islave | undefined
-      let busId: number | undefined
       if (msg !== '') {
         this.returnResult(req, res, HttpErrorsEnum.ErrBadRequest, "{message: '" + msg + "'}")
         return
       }
+      let bus:Bus| undefined = Bus.getBus(Number.parseInt(req.query.busid))
+      let slave: Islave | undefined = bus? bus.getSlaveBySlaveId(Number.parseInt(req.query.slaveid)):undefined
+
       let originalFilename: string | null = req.query.originalFilename ? req.query.originalFilename : null
       var rc = rd.writeSpecification(
         req.body,
         (filename: string) => {
-          if (busId != undefined && bus != undefined && slave != undefined) {
+          if ( bus != undefined && slave != undefined) {
             slave.specificationid = filename
-            new Config().writeslave(busId, slave.slaveid, slave.specificationid, slave.name)
+            new Config().writeslave(bus.getId(), slave.slaveid, slave.specificationid, slave.name)
           }
         },
         originalFilename

--- a/src/mqttdiscover.ts
+++ b/src/mqttdiscover.ts
@@ -209,6 +209,7 @@ export class MqttDiscover {
                         if (!o) log.log(LogLevelEnum.warn, 'generateDiscoveryPayloads: option with no text for ' + e.id)
                       })
                   }
+                  obj.device_class = 'enum'
                   if (e.converter.name === 'binary' && ns.device_class) obj.device_class = ns.device_class
                   break
                 case 'Inumber':
@@ -567,9 +568,10 @@ export class MqttDiscover {
       if (!cv) {
         let msg = 'No converter found for bus: ' + busid + ' slave: ' + slave.slaveid + ' entity id: ' + entity.id
         log.log(LogLevelEnum.error, msg)
-      } else if (e.mqttname && e.mqttValue && e.mqttValue && e.modbusValue.length > 0 && !e.variableConfiguration) {
-        // e.modbusValue.length == 0 > no data available
-        o[e.mqttname] = e.mqttValue
+      } else if (e.mqttname && e.mqttValue && !e.variableConfiguration) {
+        o[e.mqttname] = null // no data available
+        if(e.modbusValue.length > 0 )
+          o[e.mqttname] = e.mqttValue
         if (cv.publishModbusValues()) {
           if (o.modbusValues == undefined) o.modbusValues = {}
           o.modbusValues[e.mqttname] = e.modbusValue[0]

--- a/src/mqttdiscover.ts
+++ b/src/mqttdiscover.ts
@@ -9,6 +9,7 @@ import {
   IselectOption,
   ImodbusSpecification,
   EnumStateClasses,
+  Itext,
 } from '@modbus2mqtt/specification.shared'
 import { Ientity, ImodbusEntity, VariableTargetParameters, getSpecificationI18nEntityName } from '@modbus2mqtt/specification.shared'
 import { ClientSubscribeCallback, IClientOptions, IClientPublishOptions, MqttClient, connect } from 'mqtt'
@@ -60,7 +61,7 @@ export class MqttDiscover {
     // currently no meaningful checks
   }
   private pollCounts: Map<string, number> = new Map<string, number>()
-  private triggers: string[] = []
+  private triggers: {name: string, force:boolean}[] = []
   private onDestroy(this: MqttDiscover) {
     if (this.client) this.client.end()
   }
@@ -196,36 +197,46 @@ export class MqttDiscover {
               if (!obj.command_topic && !e.readonly) obj.command_topic = MqttDiscover.generateEntityCommandTopic(busid, slave, ent)
               switch (converter.getParameterType(e)) {
                 case 'Iselect':
-                  let ns = e.converterParameters as Iselect
-                  if (e.converter.name === 'select' && ns && ns.optionModbusValues && ns.optionModbusValues.length) {
-                    obj.options = []
-                    for (let modbusValue of ns.optionModbusValues)
-                      obj.options.push(getSpecificationI18nEntityOptionName(spec, this.language, e.id, modbusValue))
-
-                    if (obj.options == undefined || obj.options.length == 0)
-                      log.log(LogLevelEnum.warn, 'generateDiscoveryPayloads: No options specified for ' + obj.name)
-                    else
-                      obj.options.forEach((o: IselectOption) => {
-                        if (!o) log.log(LogLevelEnum.warn, 'generateDiscoveryPayloads: option with no text for ' + e.id)
-                      })
+                  if( !e.readonly){
+                    let ns = e.converterParameters as Iselect
+                    if (e.converter.name === 'select' && ns && ns.optionModbusValues && ns.optionModbusValues.length) {
+                      obj.options = []
+                      for (let modbusValue of ns.optionModbusValues)
+                        obj.options.push(getSpecificationI18nEntityOptionName(spec, this.language, e.id, modbusValue))
+  
+                      if (obj.options == undefined || obj.options.length == 0)
+                        log.log(LogLevelEnum.warn, 'generateDiscoveryPayloads: No options specified for ' + obj.name)
+                      else
+                        obj.options.forEach((o: IselectOption) => {
+                          if (!o) log.log(LogLevelEnum.warn, 'generateDiscoveryPayloads: option with no text for ' + e.id)
+                        })
+                    }
+                    obj.device_class = 'enum'
+                    if (e.converter.name === 'binary' && ns.device_class) obj.device_class = ns.device_class  
                   }
-                  obj.device_class = 'enum'
-                  if (e.converter.name === 'binary' && ns.device_class) obj.device_class = ns.device_class
                   break
                 case 'Inumber':
                   let nn = e.converterParameters as Inumber
                   if (!obj.unit_of_measurement && nn && nn.uom) obj.unit_of_measurement = nn.uom
                   if (nn && nn.device_class && nn.device_class.toLowerCase() != 'none') obj.device_class = nn.device_class
                   if (nn && nn.state_class && nn.state_class) obj.state_class = MqttDiscover.getStateClass(nn.state_class)
-                  if (e.converter.name === 'number') {
+                  if (e.converter.name === 'number' && !e.readonly) {
                     if (nn.step) obj.step = nn.step
                     if (nn.identification) {
                       if (nn.identification.min != undefined) obj.min = nn.identification.min
                       if (nn.identification.max != undefined) obj.max = nn.identification.max
                     }
                   }
-
                   break
+                case "Itext":
+                    if(!e.readonly){
+                      let nt = e.converterParameters as Itext
+                      if(nt.stringlength > 0)
+                        obj.max=nt.stringlength
+                      if( nt.identification && nt.identification.length)
+                        obj.pattern = nt.identification  
+                    }
+                  break;
               }
               payloads.push({
                 topic: this.generateEntityConfigurationTopic(busid, slave.slaveid, e),
@@ -278,7 +289,6 @@ export class MqttDiscover {
             let idx = tpx.findIndex((i) => i.topic == topic)
             if (idx >= 0) {
               tpx.splice(idx, 1)
-              debug('deleteMessage ' + topic)
             }
 
             if (tpx.length == 0) tp.delete(ids.entityid)
@@ -298,7 +308,6 @@ export class MqttDiscover {
         tpy = this.mqttDiscoveryTopics.get(ids.busSlave)!.get(ids.entityid)!
         if (!this.containsTopic({ topic: topic, payload: payload.toString() }, tpy)) {
           tpy.push({ topic: topic, payload: payload.toString() })
-          debug('addMessage:' + topic)
         } else this.updatePayload(topic, payload.toString(), tpy)
       }
     }
@@ -407,7 +416,6 @@ export class MqttDiscover {
     })
   }
   private async publishDiscoveryForSlave(bus: Bus, slave: Islave, spec: ImodbusSpecification) {
-    debug('MQTT:publishDiscoveryForSlave')
     this.getMqttClient().then((mqttClient) => {
       if (bus && slave.specification) {
         let discoveryPayloads = this.generateDiscoveryPayloads(bus.getId(), slave, spec)
@@ -415,10 +423,12 @@ export class MqttDiscover {
           let ids = this.getIdsFromDiscoveryTopic(tp.topic)
           if (ids) {
             let tpFound = this.mqttDiscoveryTopics.get(ids.busSlave)?.get(ids.entityid)
-            if (!tpFound || !this.containsTopic(tp, tpFound))
+            if (!tpFound || !this.containsTopic(tp, tpFound)){
               mqttClient.publish(tp.topic, tp.payload, retain) // async, no callback !!!
+              log.log(LogLevelEnum.notice, "published MQTT Discovery for " + tp.topic )
+              debug( "Payload:" + tp.payload)
+            }
             else {
-              debug('topic not changed for ' + tp.topic)
               let tpx = tpFound.find((t) => t.topic == tp.topic)
               if (!tpx || tp.payload != tpx.payload) {
                 debug('payload changed for ' + tp.topic)
@@ -531,16 +541,17 @@ export class MqttDiscover {
         log.log(LogLevelEnum.error, 'reading spec failed' + e.message)
         reject(e)
       }).subscribe((spec) => {
+        let key = new BusSlave(bus.getId(), slave.slaveid).key
+        let idx = this.triggers.findIndex((k) => k.name == key)
         this.publishDiscoveryForSlave(bus, slave, spec) // no wait
         // Trigger state only if it's configured to do so
         if (
           slave.pollMode == undefined ||
           [PollModes.intervall, PollModes.intervallAndTrigger].includes(slave.pollMode) ||
-          pollMode == PollModes.trigger
+          pollMode == PollModes.trigger || 
+          (idx >=0 && this.triggers[idx].force)
         )
           this.publishState(bus, slave, spec)
-        let key = new BusSlave(bus.getId(), slave.slaveid).key
-        let idx = this.triggers.findIndex((k) => k == key)
         // Remove trigger
         if (idx >= 0) this.triggers.splice(idx, 1)
         resolve()
@@ -626,7 +637,7 @@ export class MqttDiscover {
         bus.getSlaves().forEach((slave) => {
           let key = new BusSlave(bus.getId(), slave.slaveid).key
           let pc: number | undefined = this.pollCounts.get(key)
-          let trigger = this.triggers.find((k) => k == key)
+          let trigger = this.triggers.find((k) => k.name == key)
 
           if (pc == undefined || pc > (slave.polInterval != undefined ? slave.polInterval / 100 : defaultPollCount)) pc = 0
           if (pc == 0 || trigger != undefined) {
@@ -694,10 +705,10 @@ export class MqttDiscover {
     }
     for (let slaveId of slaves) this.publishEntityDeletions(busId, slaveId)
   }
-  triggerPoll(busid: number, slave: Islave) {
+  triggerPoll(busid: number, slave: Islave, force:boolean = false) {
     if (slave) {
       let key = new BusSlave(busid, slave.slaveid).key
-      this.triggers.push(key)
+      this.triggers.push({name: key, force: force})
     }
   }
   private subscribeDiscovery() {


### PR DESCRIPTION
1. publish null for unavailable values in MQTT publish state messages
2. Trigger MQTT Discovery after saving Specification
3. Fixes for MQTT Discovery for entity type Select read only and writable
4. Fix enable/disable submit button of config form(https://github.com/modbus2mqtt/angular/commit/b804761bc04ddaaf92f3794bc4c761ce2b2fc76c)
5. Add github token in addon scenario(https://github.com/modbus2mqtt/angular/commit/bfef47b24b4489db043285efa35b3626c1f8beb3) Closes #59
6. Fix select Converter if no options are passed (https://github.com/modbus2mqtt/specification/commit/57eb0fbb30607c0b690c7800e5799eab1bab5e9a)
7. read Specifications after deletion of specification (a deletion can also be an undone clone of public spec)(https://github.com/modbus2mqtt/specification/commit/d3ec6316821450732af8c2873b3d269e793adb65)
8. Copy files list from public specification to cloned specification(https://github.com/modbus2mqtt/specification/commit/2c65b29bb4683d37a041224ef22030a0c43f6a87)