### PR TITLE
Hassio addon

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "args": [  "-s", "../ssl", "-y" ,"../yaml-dir"],
       "console": "integratedTerminal",
       "env": {
-        "DEBUG": "httpserver,HttpServerBaseUrl",
+        "DEBUG": "httpserver,HttpServerBaseUrl,mqttclient",
         "NODE_OPTIONS": "--experimental-vm-modules npx jest"
       },
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,25 @@
       "type": "node"
     },
     {
+      "name": "Run Addon Service Server",
+      "preLaunchTask": "npm: serviceInstance",
+      "timeout": 10000,
+      "program": "${workspaceFolder}/dist/modbus2mqtt.js",
+      "args": [  "-y", "~/m2m/server/e2e/temp/yaml-dir-addon", "-s" ,"~/m2m/server/e2e/temp/ssl"],
+      "console": "integratedTerminal",
+      "env": {
+        "HASSIO_TOKEN": "abcd1234",
+        "DEBUG": "httpserver,HttpServerBaseUrl",
+        "NODE_OPTIONS": "--experimental-vm-modules npx jest"
+      },
+      "request": "launch",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "sourceMaps": true,  
+      "type": "node"
+    },
+    {
       "name": "Run Server TCP",
       "preLaunchTask": "npm: build.dev",
       "timeout": 10000,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,8 @@
     },
     {
       "name": "Run Addon Service Server",
-      "preLaunchTask": "npm: serviceInstance",
+      "preLaunchTask": "npm: e2e:server.debug",
+      "postDebugTask": "npm: e2e:end.debug",
       "timeout": 10000,
       "program": "${workspaceFolder}/dist/modbus2mqtt.js",
       "args": [  "-y", "~/m2m/server/e2e/temp/yaml-dir-addon", "-s" ,"~/m2m/server/e2e/temp/ssl"],

--- a/__tests__/bus_test.tsx
+++ b/__tests__/bus_test.tsx
@@ -7,7 +7,7 @@ import { ModbusServer, XYslaveid } from './../src/modbusTCPserver'
 import { IdentifiedStates } from '@modbus2mqtt/specification.shared'
 import { ConfigSpecification, IReadRegisterResultOrError, LogLevelEnum } from '@modbus2mqtt/specification'
 import { singleMutex } from './configsbase'
-import { PollModes } from '@modbus2mqtt/server.shared'
+import { Iconfiguration, PollModes } from '@modbus2mqtt/server.shared'
 
 const debug = Debug('bustest')
 const testPort = 8888
@@ -32,7 +32,7 @@ it('read slaves/delete slave/addSlave/read slave', () => {
     let slaves = bus.getSlaves()
     let oldLength = slaves.length
     expect(bus.getSlaves().find((s) => s.slaveid == 10)).not.toBeDefined()
-    bus.writeSlave(10, undefined, undefined, undefined, PollModes.intervall)
+    bus.writeSlave({slaveid: 10})
     slaves = bus.getSlaves()
     expect(slaves.length).toBeGreaterThan(oldLength)
     let b2 = Bus.getBus(0)
@@ -135,8 +135,8 @@ function testWrite(
   })
 }
 it('Bus getSpecsForDevice', (done) => {
-  prepareIdentification()
-  Config['config'].fakeModbus = true
+  prepareIdentification();
+  (Config['config'] as Iconfiguration).fakeModbus = true
   if (Config.getConfiguration().fakeModbus) debug(LogLevelEnum.notice, 'Fakemodbus')
   Bus.getBus(0)!
     .getAvailableSpecs(1, false)

--- a/__tests__/bus_test.tsx
+++ b/__tests__/bus_test.tsx
@@ -8,12 +8,13 @@ import { IdentifiedStates } from '@modbus2mqtt/specification.shared'
 import { ConfigSpecification, IReadRegisterResultOrError, LogLevelEnum } from '@modbus2mqtt/specification'
 import { singleMutex } from './configsbase'
 import { Iconfiguration, PollModes } from '@modbus2mqtt/server.shared'
+import { ConfigBus } from '../src/configbus'
 
 const debug = Debug('bustest')
 const testPort = 8888
 Config['yamlDir'] = yamlDir
 ConfigSpecification.yamlDir = yamlDir
-Config.sslDir = yamlDir
+Config['sslDir'] = yamlDir
 
 beforeAll(() => {
   jest.restoreAllMocks()
@@ -21,7 +22,12 @@ beforeAll(() => {
 
   Config['yamlDir'] = yamlDir
   new ConfigSpecification().readYaml()
-  return new Config().readYamlAsync()
+  return new Promise<void>((resolve, reject)=>{
+    new Config().readYamlAsync().then(()=>{
+      ConfigBus.readBusses()
+      resolve()
+    }).catch( reject)
+  })
 })
 
 it('read slaves/delete slave/addSlave/read slave', () => {

--- a/__tests__/bus_test.tsx
+++ b/__tests__/bus_test.tsx
@@ -21,7 +21,7 @@ beforeAll(() => {
 
   Config['yamlDir'] = yamlDir
   new ConfigSpecification().readYaml()
-  new Config().readYamlAsync()
+  return new Config().readYamlAsync()
 })
 
 it('read slaves/delete slave/addSlave/read slave', () => {
@@ -32,7 +32,7 @@ it('read slaves/delete slave/addSlave/read slave', () => {
     let slaves = bus.getSlaves()
     let oldLength = slaves.length
     expect(bus.getSlaves().find((s) => s.slaveid == 10)).not.toBeDefined()
-    bus.writeSlave({slaveid: 10})
+    bus.writeSlave({ slaveid: 10 })
     slaves = bus.getSlaves()
     expect(slaves.length).toBeGreaterThan(oldLength)
     let b2 = Bus.getBus(0)
@@ -135,8 +135,8 @@ function testWrite(
   })
 }
 it('Bus getSpecsForDevice', (done) => {
-  prepareIdentification();
-  (Config['config'] as Iconfiguration).fakeModbus = true
+  prepareIdentification()
+  ;(Config['config'] as Iconfiguration).fakeModbus = true
   if (Config.getConfiguration().fakeModbus) debug(LogLevelEnum.notice, 'Fakemodbus')
   Bus.getBus(0)!
     .getAvailableSpecs(1, false)

--- a/__tests__/bus_test.tsx
+++ b/__tests__/bus_test.tsx
@@ -22,11 +22,14 @@ beforeAll(() => {
 
   Config['yamlDir'] = yamlDir
   new ConfigSpecification().readYaml()
-  return new Promise<void>((resolve, reject)=>{
-    new Config().readYamlAsync().then(()=>{
-      ConfigBus.readBusses()
-      resolve()
-    }).catch( reject)
+  return new Promise<void>((resolve, reject) => {
+    new Config()
+      .readYamlAsync()
+      .then(() => {
+        ConfigBus.readBusses()
+        resolve()
+      })
+      .catch(reject)
   })
 })
 

--- a/__tests__/config_test.tsx
+++ b/__tests__/config_test.tsx
@@ -8,7 +8,7 @@ import AdmZip from 'adm-zip'
 import Debug from 'debug'
 import exp from 'constants'
 Config['yamlDir'] = yamlDir
-Config.sslDir = yamlDir
+Config['sslDir'] = yamlDir
 let debug = Debug('config_test')
 beforeAll(() => {
   return new Promise<void>((resolve, reject) => {

--- a/__tests__/config_test.tsx
+++ b/__tests__/config_test.tsx
@@ -121,7 +121,7 @@ it('getMqttConnectOptions: read connection from hassio', (done) => {
   let cfg = new Config()
   Config['config'].mqttusehassio = true
   cfg.getMqttConnectOptions().then((_mqttData) => {
-    expect(_mqttData.host).toBe(mqttService.host)
+    expect(_mqttData.mqttserverurl).toBe('mqtt://core-mosquitto:1883')
     expect(_mqttData.username).toBe(mqttService.username)
     expect(_mqttData.host).toBe(mqttService.host)
     mockReject = true

--- a/__tests__/configsbase.ts
+++ b/__tests__/configsbase.ts
@@ -7,45 +7,47 @@ import { Config } from '../src/config'
 export const yamlDir = '__tests__/yaml-dir'
 export let singleMutex = new Mutex()
 export enum FakeModes {
-    Poll,
-    Poll2,
-    Discovery,
-  }
+  Poll,
+  Poll2,
+  Discovery,
+}
 let debug = Debug('configsbase')
-  
+
 export class FakeMqtt {
-    disconnected = false
-    connected = true
-    isAsExcpected = false
-    constructor(
-      protected md: MqttDiscover,
-      public fakeMode: FakeModes
-    ) {}
-    public subscribe(topic: string | string[]): void {
-      debug('subscribe: ' + topic)
-    }
-    public publish(topic: string, message: string): void {
-      if (topic.startsWith(Config.getConfiguration().mqttdiscoveryprefix)) {
-        debug('publish Discovery ' + topic + '\n' + message)
-        this.md['onMqttMessage'](topic, Buffer.from(message, 'utf8'))
-      } else {
-        if (topic.endsWith('availabitlity')) {
-          debug('publish ' + topic + '\n' + message)
-        } else
-          switch (this.fakeMode) {
-            case FakeModes.Poll:
-              this.isAsExcpected = true
-              break
-            case FakeModes.Poll2:
-              this.isAsExcpected = false
-              break
-          }
-        debug('publish: ' + topic + '\n' + message)
-      }
-    }
-    public end() {
-      debug('end')
-    }
-    public on(event: 'message', cb: () => {}) {}
+  disconnected = false
+  connected = true
+  isAsExcpected = false
+  constructor(
+    protected md: MqttDiscover,
+    public fakeMode: FakeModes
+  ) {}
+  public subscribe(topic: string | string[]): void {
+    debug('subscribe: ' + topic)
   }
-  
+  public unsubscribe(topic: string | string[]): void {
+    debug('unsubscribe: ' + topic)
+  }
+  public publish(topic: string, message: Buffer): void {
+    if (topic.startsWith(Config.getConfiguration().mqttdiscoveryprefix)) {
+      debug('publish Discovery ' + topic + '\n' + message.toString())
+      this.md['onMqttMessage'](topic, message)
+    } else {
+      if (topic.endsWith('availabitlity')) {
+        debug('publish ' + topic + '\n' + message.toString())
+      } else
+        switch (this.fakeMode) {
+          case FakeModes.Poll:
+            this.isAsExcpected = true
+            break
+          case FakeModes.Poll2:
+            this.isAsExcpected = false
+            break
+        }
+      debug('publish: ' + topic + '\n' + message)
+    }
+  }
+  public end() {
+    debug('end')
+  }
+  public on(event: 'message', cb: () => {}) {}
+}

--- a/__tests__/configsbase.ts
+++ b/__tests__/configsbase.ts
@@ -1,3 +1,51 @@
 import { Mutex } from 'async-mutex'
+import { MqttDiscover } from '../src/mqttdiscover'
+import Debug from 'debug'
+import exp from 'constants'
+import { Config } from '../src/config'
+
 export const yamlDir = '__tests__/yaml-dir'
 export let singleMutex = new Mutex()
+export enum FakeModes {
+    Poll,
+    Poll2,
+    Discovery,
+  }
+let debug = Debug('configsbase')
+  
+export class FakeMqtt {
+    disconnected = false
+    connected = true
+    isAsExcpected = false
+    constructor(
+      protected md: MqttDiscover,
+      public fakeMode: FakeModes
+    ) {}
+    public subscribe(topic: string | string[]): void {
+      debug('subscribe: ' + topic)
+    }
+    public publish(topic: string, message: string): void {
+      if (topic.startsWith(Config.getConfiguration().mqttdiscoveryprefix)) {
+        debug('publish Discovery ' + topic + '\n' + message)
+        this.md['onMqttMessage'](topic, Buffer.from(message, 'utf8'))
+      } else {
+        if (topic.endsWith('availabitlity')) {
+          debug('publish ' + topic + '\n' + message)
+        } else
+          switch (this.fakeMode) {
+            case FakeModes.Poll:
+              this.isAsExcpected = true
+              break
+            case FakeModes.Poll2:
+              this.isAsExcpected = false
+              break
+          }
+        debug('publish: ' + topic + '\n' + message)
+      }
+    }
+    public end() {
+      debug('end')
+    }
+    public on(event: 'message', cb: () => {}) {}
+  }
+  

--- a/__tests__/httpserver_fakeTimer_test.tsx
+++ b/__tests__/httpserver_fakeTimer_test.tsx
@@ -8,11 +8,12 @@ import { ConfigSpecification } from '@modbus2mqtt/specification'
 import { join } from 'path'
 import { Readable } from 'stream'
 import AdmZip from 'adm-zip'
+import { ConfigBus } from '../src/configbus'
 
 const yamlDir = '__tests__/yaml-dir'
 ConfigSpecification.yamlDir = yamlDir
 new ConfigSpecification().readYaml()
-Config.sslDir = yamlDir
+Config['sslDir'] = yamlDir
 
 var httpServer: HttpServer
 
@@ -22,6 +23,7 @@ beforeAll(() => {
     Config['yamlDir'] = yamlDir
     let cfg = new Config()
     cfg.readYamlAsync().then(() => {
+      ConfigBus.readBusses()
       HttpServer.prototype.authenticate = (req, res, next) => {
         next()
       }

--- a/__tests__/httpserver_test.tsx
+++ b/__tests__/httpserver_test.tsx
@@ -438,64 +438,64 @@ describe('http POST', () => {
   })
 
   test('POST /specification: add new Specification rename device.specification', (done) => {
-      let md = MqttDiscover['instance'] = new MqttDiscover({}, 'en')
-      ConfigBus['listeners'] = []
-      let fake = new FakeMqtt(md, FakeModes.Poll)
-      md['client'] = fake as any as MqttClient
-      md['connectMqtt'] = function (undefined, onConnected: () => void, error: (e: any) => void) {
-        onConnected()
-      }
-      let spec1: ImodbusSpecification = Object.assign(spec)
-      let lspec = yamlDir + '/local/specifications/'
-      fs.copyFileSync(lspec + 'waterleveltransmitter.yaml', lspec + 'waterleveltransmitter.bck', undefined)
+    let md = (MqttDiscover['instance'] = new MqttDiscover({}, 'en'))
+    ConfigBus['listeners'] = []
+    let fake = new FakeMqtt(md, FakeModes.Poll)
+    md['client'] = fake as any as MqttClient
+    md['connectMqtt'] = function (undefined, onConnected: () => void, error: (e: any) => void) {
+      onConnected()
+    }
+    let spec1: ImodbusSpecification = Object.assign(spec)
+    let lspec = yamlDir + '/local/specifications/'
+    fs.copyFileSync(lspec + 'waterleveltransmitter.yaml', lspec + 'waterleveltransmitter.bck', undefined)
 
-      let filename = yamlDir + '/local/specifications/waterleveltransmitter.yaml'
-      fs.unlinkSync(ConfigSpecification['getSpecificationPath'](spec1))
-      let url = apiUri.specfication + '?busid=0&slaveid=2&originalFilename=waterleveltransmitter'
+    let filename = yamlDir + '/local/specifications/waterleveltransmitter.yaml'
+    fs.unlinkSync(ConfigSpecification['getSpecificationPath'](spec1))
+    let url = apiUri.specfication + '?busid=0&slaveid=2&originalFilename=waterleveltransmitter'
 
-      //@ts-ignore
-      supertest(httpServer.app)
-        .post(url)
-        .accept('application/json')
-        .send(spec1)
-        .expect(HttpErrorsEnum.OkCreated)
-        .catch((e) => {
-          log.log(LogLevelEnum.error, JSON.stringify(e))
-          expect(1).toBeFalsy()
-        })
-        .then((_response) => {
-          // expect((response as any as Response).status).toBe(HttpErrorsEnum.ErrBadRequest)
-          let testdata: ImodbusValues = {
-            holdingRegisters: new Map<number, IReadRegisterResultOrError>(),
-            analogInputs: new Map<number, IReadRegisterResultOrError>(),
-            coils: new Map<number, IReadRegisterResultOrError>(),
-          }
-          testdata.holdingRegisters.set(100, { error: new Error('failed!!!') })
-          Bus.getBus(0)!['setModbusAddressesForSlave'](2, testdata)
-          supertest(httpServer.app)
-            .post(url)
-            .accept('application/json')
-            .send(spec1)
-            .expect(HttpErrorsEnum.OkCreated)
-            .then((response) => {
-              var found = ConfigSpecification.getSpecificationByFilename(spec1.filename)!
-              let newFilename = ConfigSpecification['getSpecificationPath'](response.body)
-              expect(fs.existsSync(newFilename)).toBeTruthy()
-              expect(getSpecificationI18nName(found!, 'en')).toBe('Water Level Transmitter')
-              expect(response)
-              done()
-            })
-            .catch((_e) => {
-              log.log(LogLevelEnum.error, _e)
-            })
-        })
-        .finally(() => {
-          fs.copyFileSync(lspec + 'waterleveltransmitter.bck', filename)
-          fs.unlinkSync(lspec + 'waterleveltransmitter.bck')
-        })
+    //@ts-ignore
+    supertest(httpServer.app)
+      .post(url)
+      .accept('application/json')
+      .send(spec1)
+      .expect(HttpErrorsEnum.OkCreated)
+      .catch((e) => {
+        log.log(LogLevelEnum.error, JSON.stringify(e))
+        expect(1).toBeFalsy()
+      })
+      .then((_response) => {
+        // expect((response as any as Response).status).toBe(HttpErrorsEnum.ErrBadRequest)
+        let testdata: ImodbusValues = {
+          holdingRegisters: new Map<number, IReadRegisterResultOrError>(),
+          analogInputs: new Map<number, IReadRegisterResultOrError>(),
+          coils: new Map<number, IReadRegisterResultOrError>(),
+        }
+        testdata.holdingRegisters.set(100, { error: new Error('failed!!!') })
+        Bus.getBus(0)!['setModbusAddressesForSlave'](2, testdata)
+        supertest(httpServer.app)
+          .post(url)
+          .accept('application/json')
+          .send(spec1)
+          .expect(HttpErrorsEnum.OkCreated)
+          .then((response) => {
+            var found = ConfigSpecification.getSpecificationByFilename(spec1.filename)!
+            let newFilename = ConfigSpecification['getSpecificationPath'](response.body)
+            expect(fs.existsSync(newFilename)).toBeTruthy()
+            expect(getSpecificationI18nName(found!, 'en')).toBe('Water Level Transmitter')
+            expect(response)
+            done()
+          })
+          .catch((_e) => {
+            log.log(LogLevelEnum.error, _e)
+          })
+      })
+      .finally(() => {
+        fs.copyFileSync(lspec + 'waterleveltransmitter.bck', filename)
+        fs.unlinkSync(lspec + 'waterleveltransmitter.bck')
+      })
   })
   test('POST /modbus/entity: update ModbusCache data', (done) => {
-      //@ts-ignore
+    //@ts-ignore
     supertest(httpServer.app)
       .post('/api/modbus/entity?busid=0&slaveid=1&entityid=1')
       .send(spec2)

--- a/__tests__/httpserver_test.tsx
+++ b/__tests__/httpserver_test.tsx
@@ -187,7 +187,7 @@ it('GET /specsForSlave', (done) => {
         (specs: IidentificationSpecification) => specs.filename == 'waterleveltransmitter'
       )
       expect(spec).not.toBeNull()
-      expect(spec.stateTopic).not.toBeNull()
+    //  expect(spec.stateTopic).not.toBeNull()
       done()
     })
 })

--- a/__tests__/modbus_test.tsx
+++ b/__tests__/modbus_test.tsx
@@ -223,7 +223,8 @@ describe('Modbus read', () => {
     if (entText.converterParameters) (entText.converterParameters as Itext).identification = 'ABCD'
     dev!.slaveid = 2
     spec.entities = [entText]
-    mr.readEntityFromModbus(Bus.getBus(1)!, 2, spec, 2).then((arg0: ImodbusEntity) => {
+    let mb = new Modbus()
+    mb.readEntityFromModbus(Bus.getBus(1)!, 2, spec, 2).then((arg0: ImodbusEntity) => {
       expect(arg0!.identified).toBe(IdentifiedStates.identified)
       done()
     }) // unidenfified

--- a/__tests__/modbus_test.tsx
+++ b/__tests__/modbus_test.tsx
@@ -122,7 +122,7 @@ function prepareIdentification() {
     prepared = true
     readConfig = new Config()
     readConfig.readYaml()
-    ConfigBus.readBusses();
+    ConfigBus.readBusses()
     new ConfigSpecification().readYaml()
     dev = ConfigBus.getSlave(0, 1)!
   }

--- a/__tests__/modbus_test.tsx
+++ b/__tests__/modbus_test.tsx
@@ -20,6 +20,7 @@ import { Islave } from '@modbus2mqtt/server.shared'
 import { ConfigSpecification, IfileSpecification, emptyModbusValues } from '@modbus2mqtt/specification'
 import { expect, xit, it, describe, beforeEach, jest, beforeAll } from '@jest/globals'
 import Debug from 'debug'
+import { ConfigBus } from '../src/configbus'
 Config['yamlDir'] = yamlDir
 Config.sslDir = yamlDir
 ConfigSpecification.yamlDir = yamlDir
@@ -121,8 +122,9 @@ function prepareIdentification() {
     prepared = true
     readConfig = new Config()
     readConfig.readYaml()
+    ConfigBus.readBusses();
     new ConfigSpecification().readYaml()
-    dev = Config.getSlave(0, 1)!
+    dev = ConfigBus.getSlave(0, 1)!
   }
 }
 
@@ -130,8 +132,9 @@ describe('Modbus read', () => {
   it('Modbus read', (done) => {
     let readConfig: Config = new Config()
     readConfig.readYaml()
+    ConfigBus.readBusses()
     new ConfigSpecification().readYaml()
-    let dev = Config.getSlave(0, 1)!
+    let dev = ConfigBus.getSlave(0, 1)!
     expect(dev).toBeDefined
     Modbus.getModbusSpecification('test', Bus.getBus(0)!, 1, dev!.specificationid!, (_e) => {
       expect(false).toBeTruthy()
@@ -335,7 +338,7 @@ it('Modbus writeEntityMqtt', (done) => {
   let readConfig: Config = new Config()
   readConfig.readYaml()
   new ConfigSpecification().readYaml()
-  let dev = Config.getSlave(0, 1)!
+  let dev = ConfigBus.getSlave(0, 1)!
   expect(dev).toBeDefined
 
   new Modbus()

--- a/__tests__/modbuscache_test.tsx
+++ b/__tests__/modbuscache_test.tsx
@@ -10,12 +10,14 @@ import { ConfigSpecification, IReadRegisterResultOrError, ImodbusValues, Logger 
 import { ModbusRegisterType } from '@modbus2mqtt/specification.shared'
 import { expect, describe, jest, beforeAll, test, afterAll } from '@jest/globals'
 import { ReadRegisterResult } from 'modbus-serial/ModbusRTU'
+import { ConfigBus } from '../src/configbus'
 const debug = Debug('modbuscachetest')
 let mockMutex = new Mutex()
 Config['yamlDir'] = yamlDir
 Config.sslDir = yamlDir
 
 new Config().readYaml()
+ConfigBus.readBusses()
 new ConfigSpecification().readYaml()
 let mockedConnectRTU = jest.fn() as jest.MockedFunction<typeof ModbusRTU.prototype.connectRTUBuffered>
 

--- a/__tests__/yaml-dir/angular/en-US/index.html
+++ b/__tests__/yaml-dir/angular/en-US/index.html
@@ -1,17 +1,14 @@
 <!doctype html>
 <html lang="en">
-
-<head>
-    <meta charset="utf-8">
+  <head>
+    <meta charset="utf-8" />
     <title>Modbus2mqtt</title>
-    <base href="/">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/x-icon" href="assets/images/icon.png">
-    <link href=”https://fonts.googleapis.com/icon?family=Material+Icons” rel=”stylesheet”>
-</head>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="assets/images/icon.png" />
+  </head>
 
-<body>
+  <body>
     <app-root></app-root>
-</body>
-
+  </body>
 </html>

--- a/__tests__/yaml-dir/local/busses/bus.0/s2.yaml
+++ b/__tests__/yaml-dir/local/busses/bus.0/s2.yaml
@@ -1,4 +1,3 @@
-specificationid: waterleveltransmitter
+specificationid: deye
 slaveid: 2
 polInterval: 100
-evalTimeout: true

--- a/__tests__/yaml-dir/local/busses/bus.0/s2.yaml
+++ b/__tests__/yaml-dir/local/busses/bus.0/s2.yaml
@@ -1,3 +1,4 @@
-specificationid: deye
+specificationid: waterleveltransmitter
 slaveid: 2
 polInterval: 100
+evalTimeout: true

--- a/__tests__/yaml-dir/local/busses/bus.0/s2.yaml
+++ b/__tests__/yaml-dir/local/busses/bus.0/s2.yaml
@@ -1,3 +1,3 @@
+specificationid: deye
 slaveid: 2
-specificationid: waterleveltransmitter
-evalTimeout: true
+polInterval: 100

--- a/__tests__/yaml-dir/local/busses/bus.0/s2.yaml
+++ b/__tests__/yaml-dir/local/busses/bus.0/s2.yaml
@@ -1,2 +1,3 @@
 slaveid: 2
 specificationid: waterleveltransmitter
+evalTimeout: true

--- a/__tests__/yaml-dir/local/modbus2mqtt.yaml
+++ b/__tests__/yaml-dir/local/modbus2mqtt.yaml
@@ -25,3 +25,4 @@ mqttusehassiotoken: false
 githubPersonalToken: "!secret githubPersonalToken"
 mqttusehassio: false
 noAuthentication: false
+supervisor_host: supervisor

--- a/__tests__/yaml-dir/local/secrets.yaml
+++ b/__tests__/yaml-dir/local/secrets.yaml
@@ -2,4 +2,4 @@ mqttpassword: modbus2mqtt
 mqttuser: modbus2mqtt
 githubPersonalToken: someToken
 username: test
-password: $2a$08$LodGc6NRXBTVUACHpLLiS..DnhmvC.qsuwh9HFVFayEyEdbyY3rUK
+password: $2a$08$txWvDL3dnmljfUTPnmpaTOzseQRVvJ5EMUsUcrHd.IqtDWTqKdAqu

--- a/__tests__/yaml-dir/local/secrets.yaml
+++ b/__tests__/yaml-dir/local/secrets.yaml
@@ -2,4 +2,4 @@ mqttpassword: modbus2mqtt
 mqttuser: modbus2mqtt
 githubPersonalToken: someToken
 username: test
-password: $2a$08$txWvDL3dnmljfUTPnmpaTOzseQRVvJ5EMUsUcrHd.IqtDWTqKdAqu
+password: $2a$08$J61qv67PhrXzhVdWxD5Hfu/n3eNSM1sFSxc0ViVfnDATB538mBJN.

--- a/__tests__/yaml-dir/local/specifications/deye.yaml
+++ b/__tests__/yaml-dir/local/specifications/deye.yaml
@@ -1,0 +1,64 @@
+filename: deye
+manufacturer: Deye
+model: SUN-10K-SG04LP3-EU
+i18n:
+  - lang: en
+    texts:
+      - textId: name
+        text: Deye Inverter
+      - textId: e1
+        text: Current Power
+      - textId: e3
+        text: Select Test
+      - textId: e3o.1
+        text: Option 1
+      - textId: e3o.2
+        text: Option 2
+      - textId: e3o.3
+        text: Option 3
+      - textId: e5
+        text: Select Test
+      - textId: e5o.1
+        text: Option 1
+      - textId: e5o.2
+        text: Option 2
+      - textId: e5o.3
+        text: Option 3
+entities:
+  - id: 0
+    mqttname: serialnumber
+    variableConfiguration:
+      targetParameter: 1
+    converter:
+      name: text
+      registerTypes: []
+    converterParameters:
+      stringlength: 12
+    registerType: 3
+    readonly: false
+    modbusAddress: 2
+  - id: 1
+    mqttname: currentpower
+    converter:
+      name: number
+      registerTypes: []
+    converterParameters:
+      uom: kW
+    registerType: 3
+    readonly: true
+    modbusAddress: 2
+  - id: 5
+    mqttname: selecttestWr
+    modbusAddress: 7
+    registerType: 3
+    readonly: true
+    converter:
+      name: select
+      registerTypes: []
+    converterParameters:
+      optionModbusValues:
+        - 1
+        - 2
+        - 3
+version: "0.3"
+testdata: {}

--- a/__tests__/yaml-dir/local/specifications/files/waterleveltransmitter/files.yaml
+++ b/__tests__/yaml-dir/local/specifications/files/waterleveltransmitter/files.yaml
@@ -3,6 +3,6 @@ files:
   - url: __tests__/yaml-dir/local/specifications/files/test.pdf/specifications/files/waterleveltransmitter/test.pdf
     fileLocation: 0
     usage: doc
-  - url: specifications/files/waterleveltransmitter/test2.jpg
+  - url: specifications/files/waterleveltransmitter/test.pdf
     fileLocation: 0
     usage: doc

--- a/__tests__/yaml-dir/local/specifications/files/waterleveltransmitter/files.yaml
+++ b/__tests__/yaml-dir/local/specifications/files/waterleveltransmitter/files.yaml
@@ -3,6 +3,6 @@ files:
   - url: __tests__/yaml-dir/local/specifications/files/test.pdf/specifications/files/waterleveltransmitter/test.pdf
     fileLocation: 0
     usage: doc
-  - url: specifications/files/waterleveltransmitter/test.pdf
+  - url: specifications/files/waterleveltransmitter/test2.jpg
     fileLocation: 0
     usage: doc

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,50 +2,48 @@ const { defineConfig } = require('cypress')
 const MqttHelper = require('./cypress/functions/mqtt')
 module.exports = defineConfig({
   e2e: {
-    baseUrl:'http://localhost',
+    baseUrl: 'http://localhost',
     setupNodeEvents(on, config) {
       // implement node event listeners here
       on('task', {
-        mqttConnect(connectionData){
-
+        mqttConnect(connectionData) {
           return new Promise((resolve, reject) => {
             // mqtt connect with onConnected = resolve
             let mqttHelper = MqttHelper.getInstance()
             mqttHelper.connect(connectionData)
-            console.log("test")
-            resolve( "connected")        
+            console.log('test')
+            resolve('connected')
           })
         },
-        mqttSubscribe(topic){
+        mqttSubscribe(topic) {
           let mqttHelper = MqttHelper.getInstance()
           mqttHelper.subscribe(topic)
           return null
         },
-        mqttPublish(topic, payload){
+        mqttPublish(topic, payload) {
           let mqttHelper = MqttHelper.getInstance()
           mqttHelper.publish(topic, payload)
           return null
         },
-        mqttGetTopicAndPayloads(){
+        mqttGetTopicAndPayloads() {
           return new Promise((resolve) => {
             let mqttHelper = MqttHelper.getInstance()
-            resolve( mqttHelper.getTopicAndPayloads())
+            resolve(mqttHelper.getTopicAndPayloads())
           })
         },
-        mqttResetTopicAndPayloads(){
+        mqttResetTopicAndPayloads() {
           let mqttHelper = MqttHelper.getInstance()
           mqttHelper.resetTopicAndPayloads()
           return null
-        }
+        },
       })
     },
     env: {
-      "mqttconnect": {
-        "mqttserverurl": "mqtt://localhost:3001",
-        "username" : "homeassistant",
-        "password" : "homeassistant"
-      }
+      mqttconnect: {
+        mqttserverurl: 'mqtt://localhost:3001',
+        username: 'homeassistant',
+        password: 'homeassistant',
+      },
     },
   },
-  
-});
+})

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,51 @@
+const { defineConfig } = require('cypress')
+const MqttHelper = require('./cypress/functions/mqtt')
+module.exports = defineConfig({
+  e2e: {
+    baseUrl:'http://localhost',
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+      on('task', {
+        mqttConnect(connectionData){
+
+          return new Promise((resolve, reject) => {
+            // mqtt connect with onConnected = resolve
+            let mqttHelper = MqttHelper.getInstance()
+            mqttHelper.connect(connectionData)
+            console.log("test")
+            resolve( "connected")        
+          })
+        },
+        mqttSubscribe(topic){
+          let mqttHelper = MqttHelper.getInstance()
+          mqttHelper.subscribe(topic)
+          return null
+        },
+        mqttPublish(topic, payload){
+          let mqttHelper = MqttHelper.getInstance()
+          mqttHelper.publish(topic, payload)
+          return null
+        },
+        mqttGetTopicAndPayloads(){
+          return new Promise((resolve) => {
+            let mqttHelper = MqttHelper.getInstance()
+            resolve( mqttHelper.getTopicAndPayloads())
+          })
+        },
+        mqttResetTopicAndPayloads(){
+          let mqttHelper = MqttHelper.getInstance()
+          mqttHelper.resetTopicAndPayloads()
+          return null
+        }
+      })
+    },
+    env: {
+      "mqttconnect": {
+        "mqttserverurl": "mqtt://localhost:3001",
+        "username" : "homeassistant",
+        "password" : "homeassistant"
+      }
+    },
+  },
+  
+});

--- a/cypress.config.mjs
+++ b/cypress.config.mjs
@@ -1,8 +1,0 @@
-export default {
-  e2e: {
-    baseUrl:'http://localhost',
-    setupNodeEvents(on, config) {
-      // implement node event listeners here
-    },
-  },
-};

--- a/cypress/e2e/discovery.cy.js
+++ b/cypress/e2e/discovery.cy.js
@@ -3,28 +3,6 @@ let defaultm2mPort = 3005
 let mqttAuthorizedPort = 3001
 let mqttUnAuthorizedPort = 3003
 
-function runRegister(authentication, port) {
-  cy.visit('http://localhost:' + port + '/' + prefix)
-  if (authentication) {
-    cy.get('[formcontrolname="username"]').type('test')
-    cy.get('[formcontrolname="password"]').type('test')
-    cy.get('button[value="authentication"]').click()
-  } else cy.get('button[value="noAuthentication"]').click()
-  cy.url().should('contain', prefix + '/configure')
-}
-function runConfig(authentication) {
-  let port = authentication ? mqttAuthorizedPort : mqttUnAuthorizedPort
-  cy.get('[formcontrolname="mqttserverurl"]').type('mqtt://localhost:' + port, { force: true })
-  cy.get('[formcontrolname="mqttserverurl"]').trigger('change')
-  if (authentication) {
-    cy.get('[formcontrolname="mqttuser"]').type('homeassistant', { force: true })
-    cy.get('[formcontrolname="mqttpassword"]').type('homeassistant', { force: true })
-    cy.get('[formcontrolname="mqttpassword"]').trigger('change')
-  }
-  cy.get('div.saveCancel button:first').click()
-  cy.url().should('contain', prefix + '/busses')
-}
-
 function runBusses() {
   cy.url().should('contain', prefix + '/busses')
   cy.get('[role="tab"] ').eq(1).click()
@@ -44,7 +22,47 @@ function runSlaves() {
   cy.get('div.card-header-buttons:first button').eq(2).click()
   cy.url().should('contain', prefix + '/specification')
 }
+function setUrls(){
+  cy.get('app-upload-files:first mat-expansion-panel-header').eq(0).click()
+  cy.get('app-upload-files:first input[type!="file"]').eq(0).focus().type('http://localhost/test.pdf{enter}', { force: true })
+  cy.get('app-upload-files:first button mat-icon:contains("add")').eq(0).click({ force: true })
 
+  cy.get('app-upload-files:first mat-expansion-panel-header').eq(1).click()
+  cy.get('app-upload-files:first input[type!="file"]').eq(1).focus().type('http://localhost/test.png{enter}', { force: true })
+  cy.get('app-upload-files:first button mat-icon:contains("add")').eq(1).click({ force: true })
+}
+function addEntity(){
+  cy.get('app-entity:first mat-expansion-panel-header').eq(0).click()
+  cy.get('app-entity:first [formcontrolname="name"]').type('the entity{enter}', { force: true })
+  cy.get('app-entity:first [formcontrolname="modbusAddress"]').type('{backspace}1{enter}', { force: true })
+  cy.get('app-entity:first mat-select[formControlName="converter"]').click().get('mat-option').contains('number').click();
+  cy.get('app-entity:first mat-expansion-panel-header').eq(1).click()
+  cy.get('app-entity:first [formcontrolname="min"]').type('0', { force: true })
+  cy.get('app-entity:first [formcontrolname="max"]').type('100', { force: true })
+  cy.get('app-entity:first mat-select[formControlName="registerType"]').click().get('mat-option').contains('Holding').click();
+  cy.get('app-entity mat-card mat-card-header button:has(mat-icon:contains("add_circle"))').click({ force: true })
+  //body > app-root > app-specification > div.flexrowsWrapWhenSmall > div > div > app-entity > mat-card > mat-card-header > div > mat-card-title > div > div
+  cy.get('div.saveCancel:first button').eq(0).should("not.is.disabled")
+
+  cy.get('div.saveCancel:first button').eq(0).trigger("click").trigger("click")
+  
+}
+function addSlave() {
+  cy.url().should('contain', prefix + '/slaves')
+  cy.get('[formcontrolname="slaveId"]').type('10{enter}', { force: true })
+  // Show specification third header button on first card
+  cy.get('[formcontrolname="detectSpec"]').click()
+  cy.get('div.card-header-buttons:first button:contains("add_box")').eq(0).click()
+  cy.url().should('contain', prefix + '/specification')
+}
+function validateMqtt(){
+  return new Promise((resolve)=>{
+    cy.task('mqttResetTopicAndPayloads').then(()=>{
+      cy.task('mqttGetTopicAndPayloads').then((tAndP) => {
+        cy.log('tAndP ' + JSON.stringify(tAndP))
+      })})
+  })
+}
 describe('MQTT Discovery Tests', () => {
   it(
     'mqtt hassio addon',
@@ -63,19 +81,19 @@ describe('MQTT Discovery Tests', () => {
       assert(mqttConnect != undefined)
       cy.task('mqttConnect', mqttConnect).then(() => {
         cy.task('mqttSubscribe', 'homeassistant/#').then((tAndP) => {
-          cy.task('mqttResetTopicAndPayloads')
-          cy.task('mqttGetTopicAndPayloads').then((tAndP) => {
-            cy.log('tAndP ' + JSON.stringify(tAndP))
-          })
           cy.log('connected')
-        })
-        runBusses()
-        runSlaves()
-        // ... add slave
-        cy.task('mqttGetTopicAndPayloads').then((tAndP) => {
-          cy.log('tAndP ' + JSON.stringify(tAndP))
-        })
+          runBusses()
+          addSlave()
+          cy.get('#specForm [formcontrolname="name"]').type('the spec{enter}', { force: true })
+
+          setUrls()
+          addEntity()
+        
+//          cy.task('mqttGetTopicAndPayloads').then((tAndP) => {
+//            cy.log('tAndP ' + JSON.stringify(tAndP))
+//          })
       })
+    })
     }
   )
 })

--- a/cypress/e2e/discovery.cy.js
+++ b/cypress/e2e/discovery.cy.js
@@ -3,66 +3,101 @@ let defaultm2mPort = 3005
 let mqttAuthorizedPort = 3001
 let mqttUnAuthorizedPort = 3003
 
-function runBusses() {
+function runBusses(willLog) {
+  let logSetting = { log: willLog }
+  cy.log("Configure Bus")
   cy.url().should('contain', prefix + '/busses')
-  cy.get('[role="tab"] ').eq(1).click()
-  cy.get('[formcontrolname="host"]').type('localhost', { force: true })
-  cy.get('[formcontrolname="port"]').type('{backspace}{backspace}{backspace}3002', { force: true })
-  cy.get('[formcontrolname="timeout"]').eq(0).type('{backspace}{backspace}{backspace}500', { force: true })
-  cy.get('[formcontrolname="host"]').trigger('change')
-  cy.get('div.card-header-buttons button:first').click()
+  cy.get('[role="tab"] ',logSetting).eq(1,logSetting).click(logSetting)
+  cy.get('[formcontrolname="host"]',logSetting).type(backspaces(10) + 'localhost', { force: true, log:willLog })
+  cy.get('[formcontrolname="port"]',logSetting).type(backspaces(10) +'3002', { force: true, log:willLog })
+  cy.get('[formcontrolname="timeout"]',logSetting).eq(0, logSetting).type(backspaces(10) +'500', { force: true, log:willLog })
+  cy.get('[formcontrolname="host"]',logSetting).trigger('change', logSetting)
+  cy.get('div.card-header-buttons button:first',logSetting).eq(0).click(logSetting)
   // List slaves second header button on first card
-  cy.get('div.card-header-buttons:first button').eq(1).click()
+  cy.get('div.card-header-buttons:first button').eq(1, logSetting).click(logSetting)
 }
 
-function runSlaves() {
+function runSlaves(willLog) {
+  let logSetting = { log: willLog }
+  cy.log("Create Slave")
   cy.url().should('contain', prefix + '/slaves')
-  cy.get('[formcontrolname="slaveId"]').type('3{enter}', { force: true })
+  cy.get('[formcontrolname="slaveId"]',logSetting).type('3{enter}', { force: true, log:willLog })
   // Show specification third header button on first card
-  cy.get('div.card-header-buttons:first button').eq(2).click()
+  cy.get('div.card-header-buttons:first button',logSetting).eq(2,logSetting).click(logSetting)
   cy.url().should('contain', prefix + '/specification')
 }
-function setUrls(){
-  cy.get('app-upload-files:first mat-expansion-panel-header').eq(0).click()
-  cy.get('app-upload-files:first input[type!="file"]').eq(0).focus().type('http://localhost/test.pdf{enter}', { force: true })
-  cy.get('app-upload-files:first button mat-icon:contains("add")').eq(0).click({ force: true })
-
-  cy.get('app-upload-files:first mat-expansion-panel-header').eq(1).click()
-  cy.get('app-upload-files:first input[type!="file"]').eq(1).focus().type('http://localhost/test.png{enter}', { force: true })
-  cy.get('app-upload-files:first button mat-icon:contains("add")').eq(1).click({ force: true })
-}
-function addEntity(){
-  cy.get('app-entity:first mat-expansion-panel-header').eq(0).click()
-  cy.get('app-entity:first [formcontrolname="name"]').type('the entity{enter}', { force: true })
-  cy.get('app-entity:first [formcontrolname="modbusAddress"]').type('{backspace}1{enter}', { force: true })
-  cy.get('app-entity:first mat-select[formControlName="converter"]').click().get('mat-option').contains('number').click();
-  cy.get('app-entity:first mat-expansion-panel-header').eq(1).click()
-  cy.get('app-entity:first [formcontrolname="min"]').type('0', { force: true })
-  cy.get('app-entity:first [formcontrolname="max"]').type('100', { force: true })
-  cy.get('app-entity:first mat-select[formControlName="registerType"]').click().get('mat-option').contains('Holding').click();
-  cy.get('app-entity mat-card mat-card-header button:has(mat-icon:contains("add_circle"))').click({ force: true })
-  //body > app-root > app-specification > div.flexrowsWrapWhenSmall > div > div > app-entity > mat-card > mat-card-header > div > mat-card-title > div > div
-  cy.get('div.saveCancel:first button').eq(0).should("not.is.disabled")
-
-  cy.get('div.saveCancel:first button').eq(0).trigger("click").trigger("click")
+function setUrls(willLog){
+  let logSetting = { log: willLog }
+  cy.log("Set Upload files URLs")
+  cy.get('app-upload-files:first mat-expansion-panel-header',logSetting).eq(1,logSetting).click(logSetting)
+  cy.get('app-upload-files:first input[type!="file"]',logSetting).eq(1,logSetting).focus(logSetting).type('http://localhost/test.png', { force: true, log:willLog })
+  cy.get('app-upload-files:first button mat-icon:contains("add")',logSetting).eq(1,logSetting).click({ force: true, log:willLog })
   
+  cy.get('app-upload-files:first mat-expansion-panel-header',logSetting).eq(0,logSetting).click(logSetting)
+  cy.get('app-upload-files:first input[type!="file"]',logSetting).eq(0,logSetting).focus(logSetting).type('http://localhost/test.pdf', { force: true, log:willLog })
+  cy.get('app-upload-files:first button mat-icon:contains("add")',logSetting).eq(0,logSetting).click({ force: true, log:willLog  }).wait(1000)
+
 }
-function addSlave() {
+function addEntity(entitynum, modbusAddress, willLog){
+  let logSetting = { log: willLog }
+  cy.log("Add entity " + entitynum)
+  cy.get('app-entity:last mat-expansion-panel-header[aria-expanded=false]',logSetting).then((elements=>{
+    if( elements.length >=1 ){
+      elements[0].click(logSetting)
+    }
+    if( elements.length >=2 ){
+      elements[1].click(logSetting)
+    }
+  }))
+
+//  cy.get('app-entity:last mat-expansion-panel-header',logSetting).eq(0,logSetting).click(logSetting)
+  cy.get('app-entity:last [formcontrolname="name"]',logSetting).type('the entity'+ entitynum + '{enter}', { force: true, log:willLog })
+  cy.get('app-entity:last [formcontrolname="modbusAddress"]',logSetting).type('{backspace}' + modbusAddress+ '{enter}', { force: true, log:willLog })
+  cy.get('app-entity:last mat-select[formControlName="converter"]',logSetting).click().get('mat-option').contains('number').click(logSetting);
+  
+
+  cy.get('app-entity:last [formcontrolname="min"]',logSetting).type('0', { force: true, log:willLog })
+  cy.get('app-entity:last [formcontrolname="max"]',logSetting).type('1000', { force: true, log:willLog })
+  cy.get('app-entity:last mat-select[formControlName="registerType"]',logSetting).click().get('mat-option').contains('Holding').click(logSetting);
+  cy.get('app-entity:last mat-card mat-card-header button:has(mat-icon:contains("add_circle"))',logSetting).last().click({ force: true, log:willLog })
+}
+function saveSpecification(willLog){
+  let logSetting = { log: willLog }
+  cy.log("Save Specification ")
+    cy.get('div.saveCancel:first button', logSetting).eq(0, logSetting).should("not.is.disabled")
+    cy.get('div.saveCancel:first button',logSetting).eq(0,logSetting).trigger("click",logSetting)
+    cy.get('div.saveCancel:first button', logSetting).eq(0, logSetting).should("is.disabled")
+    cy.get('div.saveCancel:first button', logSetting).eq(1, logSetting).trigger("click",logSetting)  
+    cy.url().should('contain', prefix + '/slaves')
+  }
+function addSlave(willLog) {
+  let logSetting = { log: willLog }
+  cy.log("Add Slave ")
   cy.url().should('contain', prefix + '/slaves')
-  cy.get('[formcontrolname="slaveId"]').type('10{enter}', { force: true })
+  cy.get('[formcontrolname="detectSpec"]', logSetting).click( logSetting)
+  cy.get('[formcontrolname="slaveId"]', logSetting).type('10{enter}', { force: true, log:willLog })
   // Show specification third header button on first card
-  cy.get('[formcontrolname="detectSpec"]').click()
-  cy.get('div.card-header-buttons:first button:contains("add_box")').eq(0).click()
+  cy.get('div.card-header-buttons:first button:contains("add_box")', logSetting).eq(0, logSetting).click( logSetting)
   cy.url().should('contain', prefix + '/specification')
 }
-function validateMqtt(){
+function validateMqtt(willLog){
+  let logSetting = { log: willLog }
   return new Promise((resolve)=>{
-    cy.task('mqttResetTopicAndPayloads').then(()=>{
-      cy.task('mqttGetTopicAndPayloads').then((tAndP) => {
+    cy.log("Validate MQTT")
+    cy.task('mqttResetTopicAndPayloads', logSetting).then(()=>{
+      cy.task('mqttGetTopicAndPayloads', logSetting).then((tAndP) => {
         cy.log('tAndP ' + JSON.stringify(tAndP))
       })})
   })
 }
+function backspaces(num){
+  let rc = ""
+  for(let a=0; a < num; a++)
+    rc = rc + "{backspace}"
+  return rc
+} 
+
+
 describe('MQTT Discovery Tests', () => {
   it(
     'mqtt hassio addon',
@@ -73,27 +108,36 @@ describe('MQTT Discovery Tests', () => {
       },
     },
     () => {
-      cy.exec('npm run e2e:reset')
+      let willLog= true
+      let logSetting = { log: willLog }
+      cy.exec('npm run e2e:reset', logSetting)
       prefix = 'modbus2mqtt'
-      cy.visit('http://localhost:80/' + prefix)
+      cy.visit('http://localhost:80/' + prefix, logSetting)
       // monitor discovery topics
       let mqttConnect = Cypress.env('mqttconnect')
       assert(mqttConnect != undefined)
-      cy.task('mqttConnect', mqttConnect).then(() => {
-        cy.task('mqttSubscribe', 'homeassistant/#').then((tAndP) => {
-          cy.log('connected')
-          runBusses()
-          addSlave()
-          cy.get('#specForm [formcontrolname="name"]').type('the spec{enter}', { force: true })
+      cy.log("MQTT connect")
+      cy.task('mqttConnect', mqttConnect, logSetting).then(() => {
+        cy.task('mqttSubscribe', 'homeassistant/#', logSetting).then((tAndP) => {
+          cy.task("mqttResetTopicAndPayloads").then(() => {
+          runBusses(true)
+          addSlave(true)
+          cy.log("Configure Specification name")
+          cy.get('#specForm [formcontrolname="name"]', {log:false}).type(backspaces(10) + 'the spec{enter}', { force: true, log: willLog })
 
-          setUrls()
-          addEntity()
+          setUrls(true)
+          addEntity(1,1,false )
+          addEntity(2,3,false )
+          Cypress.config('defaultCommandTimeout', 20000 )
+          saveSpecification(false)
+          
+          cy.task('mqttGetTopicAndPayloads').then((tAndP) => {
+            cy.log('tAndP ' + JSON.stringify(tAndP, null, 4))
+          })
+          })
+          cy.readFile('e2e/temp/yaml-dir-addon/local/specifications/files/thespec/files.yaml').should("exist")
         
-//          cy.task('mqttGetTopicAndPayloads').then((tAndP) => {
-//            cy.log('tAndP ' + JSON.stringify(tAndP))
-//          })
-      })
     })
-    }
-  )
+    })
+})
 })

--- a/cypress/e2e/discovery.cy.js
+++ b/cypress/e2e/discovery.cy.js
@@ -1,0 +1,78 @@
+
+let prefix = ''
+let defaultm2mPort = 3005
+let mqttAuthorizedPort = 3001
+let mqttUnAuthorizedPort = 3003
+
+function runRegister(authentication, port) {
+  cy.visit('http://localhost:' + port + '/' + prefix)
+  if (authentication) {
+    cy.get('[formcontrolname="username"]').type('test')
+    cy.get('[formcontrolname="password"]').type('test')
+    cy.get('button[value="authentication"]').click()
+  } else cy.get('button[value="noAuthentication"]').click()
+  cy.url().should('contain', prefix + '/configure')
+}
+function runConfig(authentication) {
+  let port = authentication ? mqttAuthorizedPort : mqttUnAuthorizedPort
+  cy.get('[formcontrolname="mqttserverurl"]').type('mqtt://localhost:' + port, { force: true })
+  cy.get('[formcontrolname="mqttserverurl"]').trigger('change')
+  if (authentication) {
+    cy.get('[formcontrolname="mqttuser"]').type('homeassistant', { force: true })
+    cy.get('[formcontrolname="mqttpassword"]').type('homeassistant', { force: true })
+    cy.get('[formcontrolname="mqttpassword"]').trigger('change')
+  }
+  cy.get('div.saveCancel button:first').click()
+  cy.url().should('contain', prefix + '/busses')
+}
+
+function runBusses() {
+  cy.url().should('contain', prefix + '/busses')
+  cy.get('[role="tab"] ').eq(1).click()
+  cy.get('[formcontrolname="host"]').type('localhost', { force: true })
+  cy.get('[formcontrolname="port"]').type('{backspace}{backspace}{backspace}3002', { force: true })
+  cy.get('[formcontrolname="timeout"]').eq(0).type('{backspace}{backspace}{backspace}500', { force: true })
+  cy.get('[formcontrolname="host"]').trigger('change')
+  cy.get('div.card-header-buttons button:first').click()
+  // List slaves second header button on first card
+  cy.get('div.card-header-buttons:first button').eq(1).click()
+}
+
+function runSlaves() {
+  cy.url().should('contain', prefix + '/slaves')
+  cy.get('[formcontrolname="slaveId"]').type('3{enter}', { force: true })
+  // Show specification third header button on first card
+  cy.get('div.card-header-buttons:first button').eq(2).click()
+  cy.url().should('contain', prefix + '/specification')
+}
+
+
+describe('MQTT Discovery Tests', () => {
+  it('mqtt hassio addon',{
+    retries: {
+      runMode: 3,
+      openMode: 1,
+    },
+  }, () => {
+    cy.exec('npm run e2e:reset')
+    prefix = 'modbus2mqtt'
+    cy.visit('http://localhost:80/' + prefix)
+    // monitor discovery topics
+    let mqttConnect = Cypress.env('mqttconnect')
+    assert( mqttConnect != undefined)
+    cy.task('mqttConnect', mqttConnect).then(() => {
+        cy.task('mqttSubscribe', "homeassistant/#" ).then((tAndP)=>{
+        cy.task('mqttGetTopicAndPayloads' ).then((tAndP)=>{
+        assert(tAndP.length == 0)
+      })
+      cy.log( "connected")
+    })
+    runBusses()
+    runSlaves()
+    // ... add slave
+    cy.task('mqttGetTopicAndPayloads' ).then((tAndP)=>{
+      cy.log("tAndP " + JSON.stringify(tAndP))
+    })
+  })
+})
+})

--- a/cypress/e2e/discovery.cy.js
+++ b/cypress/e2e/discovery.cy.js
@@ -1,4 +1,3 @@
-
 let prefix = ''
 let defaultm2mPort = 3005
 let mqttAuthorizedPort = 3001
@@ -46,33 +45,37 @@ function runSlaves() {
   cy.url().should('contain', prefix + '/specification')
 }
 
-
 describe('MQTT Discovery Tests', () => {
-  it('mqtt hassio addon',{
-    retries: {
-      runMode: 3,
-      openMode: 1,
+  it(
+    'mqtt hassio addon',
+    {
+      retries: {
+        runMode: 3,
+        openMode: 1,
+      },
     },
-  }, () => {
-    cy.exec('npm run e2e:reset')
-    prefix = 'modbus2mqtt'
-    cy.visit('http://localhost:80/' + prefix)
-    // monitor discovery topics
-    let mqttConnect = Cypress.env('mqttconnect')
-    assert( mqttConnect != undefined)
-    cy.task('mqttConnect', mqttConnect).then(() => {
-        cy.task('mqttSubscribe', "homeassistant/#" ).then((tAndP)=>{
-        cy.task('mqttGetTopicAndPayloads' ).then((tAndP)=>{
-        assert(tAndP.length == 0)
+    () => {
+      cy.exec('npm run e2e:reset')
+      prefix = 'modbus2mqtt'
+      cy.visit('http://localhost:80/' + prefix)
+      // monitor discovery topics
+      let mqttConnect = Cypress.env('mqttconnect')
+      assert(mqttConnect != undefined)
+      cy.task('mqttConnect', mqttConnect).then(() => {
+        cy.task('mqttSubscribe', 'homeassistant/#').then((tAndP) => {
+          cy.task('mqttResetTopicAndPayloads')
+          cy.task('mqttGetTopicAndPayloads').then((tAndP) => {
+            cy.log('tAndP ' + JSON.stringify(tAndP))
+          })
+          cy.log('connected')
+        })
+        runBusses()
+        runSlaves()
+        // ... add slave
+        cy.task('mqttGetTopicAndPayloads').then((tAndP) => {
+          cy.log('tAndP ' + JSON.stringify(tAndP))
+        })
       })
-      cy.log( "connected")
-    })
-    runBusses()
-    runSlaves()
-    // ... add slave
-    cy.task('mqttGetTopicAndPayloads' ).then((tAndP)=>{
-      cy.log("tAndP " + JSON.stringify(tAndP))
-    })
-  })
-})
+    }
+  )
 })

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,4 +1,3 @@
-
 let prefix = ''
 let defaultm2mPort = 3005
 let mqttAuthorizedPort = 3001
@@ -46,39 +45,50 @@ function runSlaves() {
   cy.url().should('contain', prefix + '/specification')
 }
 
-
 describe('End to End Tests', () => {
-  it('register->mqtt->busses->slaves->specification with authentication',{
-    retries: {
-      runMode: 3,
-      openMode: 1,
-    },
-  }, () => {
-    cy.exec('npm run e2e:reset')
-    runRegister(true, defaultm2mPort)
-    runConfig(true)
-    runBusses()
-    runSlaves()
-  })
-  it('register->mqtt with no authentication',{
+  it(
+    'register->mqtt->busses->slaves->specification with authentication',
+    {
       retries: {
         runMode: 3,
         openMode: 1,
       },
-    }, () => {
-    cy.exec('npm run e2e:reset')
-    runRegister(false, defaultm2mPort)
-    runConfig(false)
-  })
-  it('mqtt hassio addon',{
-    retries: {
-      runMode: 3,
-      openMode: 1,
     },
-  }, () => {
-    cy.exec('npm run e2e:reset')
-    prefix = 'modbus2mqtt'
-    cy.visit('http://localhost:80/' + prefix)
-    runBusses()
-  })
+    () => {
+      cy.exec('npm run e2e:reset')
+      runRegister(true, defaultm2mPort)
+      runConfig(true)
+      runBusses()
+      runSlaves()
+    }
+  )
+  it(
+    'register->mqtt with no authentication',
+    {
+      retries: {
+        runMode: 3,
+        openMode: 1,
+      },
+    },
+    () => {
+      cy.exec('npm run e2e:reset')
+      runRegister(false, defaultm2mPort)
+      runConfig(false)
+    }
+  )
+  it(
+    'mqtt hassio addon',
+    {
+      retries: {
+        runMode: 3,
+        openMode: 1,
+      },
+    },
+    () => {
+      cy.exec('npm run e2e:reset')
+      prefix = 'modbus2mqtt'
+      cy.visit('http://localhost:80/' + prefix)
+      runBusses()
+    }
+  )
 })

--- a/cypress/functions/mqtt.js
+++ b/cypress/functions/mqtt.js
@@ -1,0 +1,52 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const mqtt = require('mqtt')
+let instance = undefined;
+exports.MqttHelper = void 0;
+function getInstance(){
+
+    if(instance == undefined)
+        instance = new MqttHelper()
+    return instance;
+}
+class MqttHelper{
+    client;
+    tAndP=[];
+
+    static getInstance(){
+
+        if(MqttHelper.instance == undefined)
+            MqttHelper.instance = new MqttHelper()
+        return MqttHelper.instance;
+    }
+    onMessage(topic, payload){
+        this.tAndP.push({topic: topic, payload: payload})
+    }
+
+    connect(connectionData){
+        return new Promise((resolve,reject)=>{
+            this.client = mqtt.connect(connectionData.mqttserverurl, connectionData )
+            this.client.on('error', reject)
+            this.client.on('message', this.onMessage)
+            this.client.on('connect', () => {
+              resolve()
+            })
+        })
+    }
+    publish( topic, payload ){
+        this.client.publish(topic, payload, {qos: 1 })
+    }
+    subscribe( topic){
+        this.client.subscribe(topic, {qos: 1 })
+    }
+    getTopicAndPayloads(){
+        return new Promise((resolve)=>{
+            resolve( this.tAndP )
+        })
+    }
+    resetTopicAndPayloads(){
+        this.tAndP = []
+    }
+}
+exports.getInstance = getInstance
+exports.MqttHelper = MqttHelper;

--- a/cypress/functions/mqtt.js
+++ b/cypress/functions/mqtt.js
@@ -16,13 +16,14 @@ class MqttHelper {
   tAndP
   constructor() {
     this.tAndP = []
-    console.log('constructore')
   }
 
-  onMessage(topic, payload) {
-    console.log('onMessage' + topic )
-    if (this.tAndP) this.tAndP.push({ topic: topic, payload: payload.toString() })
-    else console.log('tAndP is undefined')
+  onMessage(topic, payload, packet) {
+    if (this.tAndP && ! this.tAndP.find(tp=>tp.messageId == packet.messageId )) 
+    {
+      console.log('onMessage id:' + packet.messageId + " topic:" + topic + " payload: " + payload.toString())
+      this.tAndP.push({ topic: topic, payload: payload.toString(), messageId: packet.messageId })
+    }
   }
 
   connect(connectionData) {
@@ -39,17 +40,14 @@ class MqttHelper {
     this.client.publish(topic, payload, { qos: 1 })
   }
   subscribe(topic) {
-    console.log('subscribe')
     this.client.subscribe(topic, { qos: 1 })
   }
   getTopicAndPayloads() {
-    console.log('getTopicsAndPayload: ' + this.tAndP.length)
     return new Promise((resolve) => {
       resolve(this.tAndP)
     })
   }
   resetTopicAndPayloads() {
-    console.log('reset')
     if (this.tAndP == undefined) console.log('resetTopicAndPayloads this.tAndP is undefined')
     this.tAndP = []
   }

--- a/cypress/functions/mqtt.js
+++ b/cypress/functions/mqtt.js
@@ -20,7 +20,7 @@ class MqttHelper {
   }
 
   onMessage(topic, payload) {
-    console.log('onMessage')
+    console.log('onMessage' + topic )
     if (this.tAndP) this.tAndP.push({ topic: topic, payload: payload.toString() })
     else console.log('tAndP is undefined')
   }

--- a/cypress/functions/mqtt.js
+++ b/cypress/functions/mqtt.js
@@ -1,52 +1,58 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
+'use strict'
+Object.defineProperty(exports, '__esModule', { value: true })
 const mqtt = require('mqtt')
-let instance = undefined;
-exports.MqttHelper = void 0;
-function getInstance(){
-
-    if(instance == undefined)
-        instance = new MqttHelper()
-    return instance;
+let instance = undefined
+exports.MqttHelper = void 0
+function getInstance() {
+  if (instance == undefined) {
+    console.log('call new')
+    instance = new MqttHelper()
+    if (instance.tAndP == undefined) console.log('After new tAndP is undefined')
+  }
+  return instance
 }
-class MqttHelper{
-    client;
-    tAndP=[];
+class MqttHelper {
+  client
+  tAndP
+  constructor() {
+    this.tAndP = []
+    console.log('constructore')
+  }
 
-    static getInstance(){
+  onMessage(topic, payload) {
+    console.log('onMessage')
+    if (this.tAndP) this.tAndP.push({ topic: topic, payload: payload.toString() })
+    else console.log('tAndP is undefined')
+  }
 
-        if(MqttHelper.instance == undefined)
-            MqttHelper.instance = new MqttHelper()
-        return MqttHelper.instance;
-    }
-    onMessage(topic, payload){
-        this.tAndP.push({topic: topic, payload: payload})
-    }
-
-    connect(connectionData){
-        return new Promise((resolve,reject)=>{
-            this.client = mqtt.connect(connectionData.mqttserverurl, connectionData )
-            this.client.on('error', reject)
-            this.client.on('message', this.onMessage)
-            this.client.on('connect', () => {
-              resolve()
-            })
-        })
-    }
-    publish( topic, payload ){
-        this.client.publish(topic, payload, {qos: 1 })
-    }
-    subscribe( topic){
-        this.client.subscribe(topic, {qos: 1 })
-    }
-    getTopicAndPayloads(){
-        return new Promise((resolve)=>{
-            resolve( this.tAndP )
-        })
-    }
-    resetTopicAndPayloads(){
-        this.tAndP = []
-    }
+  connect(connectionData) {
+    return new Promise((resolve, reject) => {
+      this.client = mqtt.connect(connectionData.mqttserverurl, connectionData)
+      this.client.on('error', reject)
+      this.client.on('message', this.onMessage.bind(this))
+      this.client.on('connect', () => {
+        resolve()
+      })
+    })
+  }
+  publish(topic, payload) {
+    this.client.publish(topic, payload, { qos: 1 })
+  }
+  subscribe(topic) {
+    console.log('subscribe')
+    this.client.subscribe(topic, { qos: 1 })
+  }
+  getTopicAndPayloads() {
+    console.log('getTopicsAndPayload: ' + this.tAndP.length)
+    return new Promise((resolve) => {
+      resolve(this.tAndP)
+    })
+  }
+  resetTopicAndPayloads() {
+    console.log('reset')
+    if (this.tAndP == undefined) console.log('resetTopicAndPayloads this.tAndP is undefined')
+    this.tAndP = []
+  }
 }
 exports.getInstance = getInstance
-exports.MqttHelper = MqttHelper;
+exports.MqttHelper = MqttHelper

--- a/e2e/localdev.sh
+++ b/e2e/localdev.sh
@@ -76,6 +76,8 @@ mkdir -p ${BASEDIR}/temp/yaml-dir-addon/local
 if [ "$1" == "reset" ]
 then
   #daemon reload is not required: No changes to service
+  systemctl --user restart mosquitto.service
+  
   systemctl --user restart modbus2mqtt-e2e.service
   systemctl --user restart modbus2mqtt-addon.service
   checkServices
@@ -96,12 +98,10 @@ echo configure nginx
 sudo bash -c 'cat >'$WWWROOT'/services/mqtt/mqtt.json <<EOF
 {
   "data":{
-    "mqttconnect": {
       "host" : "localhost",
       "port" : 3001,
       "username" : "homeassistant",
       "password" : "homeassistant"
-    }
   }
 }
 EOF'
@@ -232,6 +232,7 @@ StartLimitIntervalSec=1
 [Service]
 Type=simple
 Environment="HASSIO_TOKEN=abcd1234"
+Environment="DEBUG=config.addon"
 ExecStart=|node| |cwd|/dist/modbus2mqtt.js -y |cwd|/e2e/temp/yaml-dir-addon -s |cwd|/e2e/temp/ssl 
 [Install]
 WantedBy=multi-user.target

--- a/e2e/localdev.sh
+++ b/e2e/localdev.sh
@@ -9,16 +9,27 @@
 set -e
 
 export SERVICES=~/.config/systemd/user/
-function services(){
+function basicServices(){
     echo modbus2mqtt-tcp-server.service 3002
     echo mosquitto.service 3001
     echo mosquitto.service 3003
+}
+
+function services(){
+    basicServices
     echo modbus2mqtt-e2e.service 3005  modbus2mqtt-e2e.service.log
     echo modbus2mqtt-addon.service 3004
 }
 function checkServices(){
   sleep 2
-  services | while read service port log
+  {
+    if [ "$1" != "" ] 
+    then
+      basicServices
+    else
+      services
+    fi
+  } | while read service port log
   do
     if ! systemctl --user is-active --quiet $service
     then
@@ -76,15 +87,26 @@ mkdir -p ${BASEDIR}/temp/yaml-dir-addon/local
 if [ "$1" == "reset" ]
 then
   #daemon reload is not required: No changes to service
-  systemctl --user restart mosquitto.service
-  
-  systemctl --user restart modbus2mqtt-e2e.service
-  systemctl --user restart modbus2mqtt-addon.service
-  checkServices
+  if [ -f "e2e/temp/addon.debug" ]
+  then
+    systemctl --user start modbus2mqtt-tcp-server.service
+    systemctl --user restart mosquitto.service  
+    #debugging: No start of service. The servers will run in the IDE
+    systemctl --user stop modbus2mqtt-e2e.service
+    systemctl --user stop modbus2mqtt-addon.service
+    exit 0
+  else
+    systemctl --user start modbus2mqtt-tcp-server.service
+    systemctl --user restart mosquitto.service  
+    systemctl --user restart modbus2mqtt-e2e.service
+    systemctl --user restart modbus2mqtt-addon.service
+    checkServices
+  fi 
 fi
 
 # .../server/e2e
-
+if [ "$1" == "root" ]
+then
 # Root part START
 set +e
 sudo apt-get install -y nginx mosquitto mosquitto-clients >/dev/null 2>&1
@@ -160,6 +182,8 @@ EOF2' | sed -e "s:|wwwroot|:${WWWROOT}:g" | sudo sh -c "cat >/etc/nginx/conf.d/m
 sudo systemctl daemon-reload
 sudo systemctl stop mosquitto.service
 sudo systemctl restart nginx.service
+exit 0
+fi 
 # Root part END
 
 mkdir -p $SERVICES
@@ -261,6 +285,6 @@ sleep 1
 systemctl --user restart modbus2mqtt-tcp-server.service
 systemctl --user restart modbus2mqtt-e2e.service
 systemctl --user restart modbus2mqtt-addon.service
-systemctl --user restart mosquitto.service
+systemctl --user start mosquitto.service
 checkServices
 

--- a/e2e/localdev.sh
+++ b/e2e/localdev.sh
@@ -144,7 +144,7 @@ server {
      root |wwwroot|;
      index info.json;
   }
-  location /addons/hardware/info {
+  location /hardware/info {
      root |wwwroot|;
      index hardware.json;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@modbus2mqtt/server",
-  "version": "0.16.14",
+  "version": "0.16.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modbus2mqtt/server",
-      "version": "0.16.14",
+      "version": "0.16.15",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/translate": "^8.3.0",
-        "@modbus2mqtt/angular": "^0.12.11",
-        "@modbus2mqtt/server.shared": "^0.13.7",
-        "@modbus2mqtt/specification": "^0.15.21",
-        "@modbus2mqtt/specification.shared": "^0.10.6",
+        "@modbus2mqtt/angular": "^0.12.12",
+        "@modbus2mqtt/server.shared": "^0.13.8",
+        "@modbus2mqtt/specification": "^0.15.22",
+        "@modbus2mqtt/specification.shared": "^0.10.7",
         "@octokit/rest": "^20.1.1",
         "adm-zip": "^0.5.16",
         "assert": "^2.1.0",
@@ -82,54 +82,8 @@
         "ts-node": "^10.9.2",
         "tslib": "^2.6.3",
         "tsx": "^4.16.5",
-        "typescript": "^5.5.4",
+        "typescript": "*",
         "typescript-map": "^0.1.0"
-      }
-    },
-    "../specification": {
-      "name": "@modbus2mqtt/specification",
-      "version": "0.15.20",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@modbus2mqtt/specification.shared": "^0.10.6",
-        "@octokit/rest": "^20.1.1",
-        "adm-zip": "^0.5.16",
-        "commander": "^12.1.0",
-        "debug": "^4.3.7",
-        "fs": "^0.0.1-security",
-        "logger": "^0.0.1",
-        "npmlog": "^7.0.1",
-        "path": "^0.12.7",
-        "rxjs": "^7.8.1",
-        "yaml": "^2.4.5"
-      },
-      "bin": {
-        "validate": "bin/validate.js"
-      },
-      "devDependencies": {
-        "@commitlint/cli": "^19.3.0",
-        "@commitlint/config-conventional": "^19.2.2",
-        "@opengovsg/credits-generator": "^1.0.7",
-        "@types/adm-zip": "^0.5.5",
-        "@types/debug": "^4.1.12",
-        "@types/jest": "^29.5.12",
-        "@types/node": "^22.5.5",
-        "@types/npmlog": "^7.0.0",
-        "@typescript-eslint/eslint-plugin": "^8.0.0",
-        "@typescript-eslint/parser": "^8.0.0",
-        "async-mutex": "^0.5.0",
-        "eslint": "^9.8.0",
-        "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-prettier": "^5.2.1",
-        "husky": "^9.1.4",
-        "jest": "^29.7.0",
-        "nodemon": "^3.1.3",
-        "prettier": "^3.3.3",
-        "ts-jest": "^29.1.5",
-        "ts-node": "^10.9.2",
-        "tslib": "^2.6.3",
-        "typescript": "^5.4.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -146,9 +100,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "18.2.12",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-18.2.12.tgz",
-      "integrity": "sha512-XcWH/VFQ1Rddhdqi/iU8lW3Qg96yVx1NPfrO5lhcSSvVUzYWTZ5r+jh3GqYqUgPWyEp1Kpw3FLsOgVcGcBWQkQ==",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.0.3.tgz",
+      "integrity": "sha512-YWoXM2S5p+Eq6cX1xjtFaai23oVNnbf3u34pEQCyKDjZpqI5lMu8e63lQT0tf7fZttEWlNUYRTwQ9+MpZ0sjzQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -158,13 +112,13 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "18.2.12"
+        "@angular/core": "19.0.3"
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "18.2.13",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-18.2.13.tgz",
-      "integrity": "sha512-yBKoqcOwmwXnc5phFMEEMO130/Bz9beQLJrKzIS87f6TXaGCeBs4xrPHq2i7Xx/2TqvMiOD9ucjmlVbtGvNG3w==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.0.2.tgz",
+      "integrity": "sha512-eDjHJJWpgnzC3pR6N0gCdh51Q1ffoh6mql06YSqprj005aNKBjmCMnpU4bPPzdGSkKsjwAZWGUNWg4RS+R+iZQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -174,15 +128,15 @@
         "parse5": "^7.1.2"
       },
       "peerDependencies": {
-        "@angular/common": "^18.0.0 || ^19.0.0",
-        "@angular/core": "^18.0.0 || ^19.0.0",
+        "@angular/common": "^19.0.0 || ^20.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/common": {
-      "version": "18.2.12",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.12.tgz",
-      "integrity": "sha512-gI5o8Bccsi8ow8Wk2vG4Tw/Rw9LoHEA9j8+qHKNR/55SCBsz68Syg310dSyxy+sApJO2WiqIadr5VP36dlSUFw==",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.0.3.tgz",
+      "integrity": "sha512-YyBVZU+LQ38R+/U5vF/b1T3muROKpR0kkupMw7VKnGhQfgrRX5Dk3H2nr9ritt0zPc7TOUuQSlHMf3QWah2GDg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -192,14 +146,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "18.2.12",
+        "@angular/core": "19.0.3",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/core": {
-      "version": "18.2.12",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.12.tgz",
-      "integrity": "sha512-wCf/OObwS6bpM60rk6bpMpCRGp0DlMLB1WNAMtfcaPNyqimVV5Bm98mWRhkOuRyvU3fU7iHhM/10ePVaoyu9+A==",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.0.3.tgz",
+      "integrity": "sha512-WM844gDzrbHtcM2TJB9DmfCmenUYyNSI6h924CeppDW5oG8ShinQGiWNjF5oI6EZ4tG60uK3QvCm3kjr1dmbOA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -210,13 +164,13 @@
       },
       "peerDependencies": {
         "rxjs": "^6.5.3 || ^7.4.0",
-        "zone.js": "~0.14.10"
+        "zone.js": "~0.15.0"
       }
     },
     "node_modules/@angular/forms": {
-      "version": "18.2.12",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-18.2.12.tgz",
-      "integrity": "sha512-FsukBJEU6jfAmht7TrODTkct/o4iwCZvGozuThOp0tYUPD/E1rZZzuKjEyTnT5Azpfkf0Wqx1nmpz80cczELOQ==",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.0.3.tgz",
+      "integrity": "sha512-8wf8yDR6cW+lOhpzhmxUOiI5Wjr1Kf7o8NuJ2P5K6b7IMNRzRyR5q/6R4NUwtF6aaJ1wNqmSof+goQmtn1HOcw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -226,35 +180,35 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "18.2.12",
-        "@angular/core": "18.2.12",
-        "@angular/platform-browser": "18.2.12",
+        "@angular/common": "19.0.3",
+        "@angular/core": "19.0.3",
+        "@angular/platform-browser": "19.0.3",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/material": {
-      "version": "18.2.13",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-18.2.13.tgz",
-      "integrity": "sha512-Gxyyo6G+IXJwgf6zDTjPfFJ2PnjC2YXWKGkKKG2oR0jfiYiovDvNR4oXxhsztTwkaxLwck/gscoVTSQXMkU5fg==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-19.0.2.tgz",
+      "integrity": "sha512-IKU6znBKgD0xHEGo5WD3JWNK+WjamMCzAvSa72w4Evo2N6PWN+dAkbCMYxugW7dOfwoT8DvUnjIWclC+RRCl0A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/animations": "^18.0.0 || ^19.0.0",
-        "@angular/cdk": "18.2.13",
-        "@angular/common": "^18.0.0 || ^19.0.0",
-        "@angular/core": "^18.0.0 || ^19.0.0",
-        "@angular/forms": "^18.0.0 || ^19.0.0",
-        "@angular/platform-browser": "^18.0.0 || ^19.0.0",
+        "@angular/animations": "^19.0.0 || ^20.0.0",
+        "@angular/cdk": "19.0.2",
+        "@angular/common": "^19.0.0 || ^20.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0",
+        "@angular/forms": "^19.0.0 || ^20.0.0",
+        "@angular/platform-browser": "^19.0.0 || ^20.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "18.2.12",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.12.tgz",
-      "integrity": "sha512-DRSMznuxuecrs+v5BRyd60/R4vjkQtuYUEPfzdo+rqxM83Dmr3PGtnqPRgd5oAFUbATxf02hQXijRD27K7rZRg==",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.0.3.tgz",
+      "integrity": "sha512-vggWHSzOsCpYqnGq5IIN+n7xdEvXfgUGaMdgzPhFMTsnlMTUs5+VEFl9tX9FANHkXKB5S1RttVyvEXRqJM9ncQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -264,9 +218,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "18.2.12",
-        "@angular/common": "18.2.12",
-        "@angular/core": "18.2.12"
+        "@angular/animations": "19.0.3",
+        "@angular/common": "19.0.3",
+        "@angular/core": "19.0.3"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -2528,30 +2482,30 @@
       }
     },
     "node_modules/@modbus2mqtt/angular": {
-      "version": "0.12.11",
-      "resolved": "https://registry.npmjs.org/@modbus2mqtt/angular/-/angular-0.12.11.tgz",
-      "integrity": "sha512-mFyuV7bO7lXjegOlFzyDvfdvV9RBiXkACxQmlq0y8rMKZYS27eVEdMFdo9mTnQ+dNWwPzJvICHAR1C7ZlQhoGw==",
+      "version": "0.12.12",
+      "resolved": "https://registry.npmjs.org/@modbus2mqtt/angular/-/angular-0.12.12.tgz",
+      "integrity": "sha512-l0ecek4FEO1YUrDg4ZuO2K3lq+0YAj+5uEWRDvTc2vqwunx4pgm4CpYSsH3arMUYDl+Xtk2K/8orc1nW4kboAQ==",
       "dependencies": {
         "mat-icon-button-sizes": "^1.0.6"
       }
     },
     "node_modules/@modbus2mqtt/server.shared": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/@modbus2mqtt/server.shared/-/server.shared-0.13.7.tgz",
-      "integrity": "sha512-FU6+QEKAK9IJ9RoI0rB53qUgTe9I4Tl+NgmxYLCuKdZu9mFbP67uurqvt9VpPTGHjQdSIW8f9PFeavnW5HZ4pQ==",
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/@modbus2mqtt/server.shared/-/server.shared-0.13.8.tgz",
+      "integrity": "sha512-Lx/woe1HQcUsmpsazqkDcC2wurIVqGi0+esDQQ5pThmLc4mnbzyOeGU0C4R0MXwkpm6SquQezk3bYq4VKz2kWw==",
       "license": "MIT",
       "dependencies": {
-        "@modbus2mqtt/specification.shared": "^0.10.6",
+        "@modbus2mqtt/specification.shared": "^0.10.7",
         "mqtt": "^5.7.1"
       }
     },
     "node_modules/@modbus2mqtt/specification": {
-      "version": "0.15.21",
-      "resolved": "https://registry.npmjs.org/@modbus2mqtt/specification/-/specification-0.15.21.tgz",
-      "integrity": "sha512-XiqyNcpta1bBRbNQlD946rC7j41doFGkwvvXz527EBC3bT678kjmA+eup/dSMVSmZoRigSJd7/aMKXltqXEV0w==",
+      "version": "0.15.22",
+      "resolved": "https://registry.npmjs.org/@modbus2mqtt/specification/-/specification-0.15.22.tgz",
+      "integrity": "sha512-apYpI09MXCcPE1FfYwinzAMUzfLqBF2HudSffatQWfHIMk3QhIptvI+HsIht3rI9xRj0X4MaFM4H3P/Y3f2Ezg==",
       "license": "MIT",
       "dependencies": {
-        "@modbus2mqtt/specification.shared": "^0.10.6",
+        "@modbus2mqtt/specification.shared": "^0.10.7",
         "@octokit/rest": "^20.1.1",
         "adm-zip": "^0.5.16",
         "commander": "^12.1.0",
@@ -2568,9 +2522,9 @@
       }
     },
     "node_modules/@modbus2mqtt/specification.shared": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@modbus2mqtt/specification.shared/-/specification.shared-0.10.6.tgz",
-      "integrity": "sha512-Xy3o72addoANnJW7n8AqV7duEzb9NAB62RNkdBxN7CxIxTaot3PCJCtgia9bHlwLk2Sx2K1ycFJXuxh0QkiF1A==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@modbus2mqtt/specification.shared/-/specification.shared-0.10.7.tgz",
+      "integrity": "sha512-VmN6b3hhtttTlezsV6y1E8H0FvbP4ntsvIODZbh3Goh7FaFyrn3cOQI/sMFnoZSRwAKyFdMd54TFrg3tIW49gw==",
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -18446,9 +18400,9 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.10.tgz",
-      "integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.0.tgz",
+      "integrity": "sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==",
       "license": "MIT",
       "peer": true
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modbus2mqtt/server",
-  "version": "0.16.14",
+  "version": "0.16.15",
   "sshserver": "homeassistant@homeassistant.lan",
   "homepage": "https://github.com/modbus2mqtt/server/README.md",
   "description": "server for modbus2mqtt for REST API of configuration and publishing modbus values to mqtt",
@@ -31,14 +31,16 @@
     "build.docker": "docker buildx build --load --tag modbus2mqtt/server docker",
     "ng serve": "cd ../angular && ng serve --open",
     "e2e:reset": "./e2e/localdev.sh reset",
+    "e2e:server.debug": "npm run build.dev && touch 'e2e/temp/addon.debug'",
+    "e2e:end.debug": "rm 'e2e/temp/addon.debug'",
     "prettier": "prettier --write '**/*.{ts,js,css,html,tsx}'"
   },
   "dependencies": {
     "@google-cloud/translate": "^8.3.0",
-    "@modbus2mqtt/angular": "^0.12.11",
-    "@modbus2mqtt/server.shared": "^0.13.7",
-    "@modbus2mqtt/specification": "^0.15.21",
-    "@modbus2mqtt/specification.shared": "^0.10.6",
+    "@modbus2mqtt/angular": "^0.12.12",
+    "@modbus2mqtt/server.shared": "^0.13.8",
+    "@modbus2mqtt/specification": "^0.15.22",
+    "@modbus2mqtt/specification.shared": "^0.10.7",
     "@octokit/rest": "^20.1.1",
     "adm-zip": "^0.5.16",
     "assert": "^2.1.0",
@@ -104,7 +106,7 @@
     "ts-node": "^10.9.2",
     "tslib": "^2.6.3",
     "tsx": "^4.16.5",
-    "typescript": "^5.5.4",
+    "typescript": "*",
     "typescript-map": "^0.1.0"
   }
 }

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -484,7 +484,7 @@ export class Bus {
     debug('getAllModbusAddresses')
     if (!Bus.allSpecificationsModbusAddresses) {
       Bus.updateAllSpecificationsModbusAddresses(null)
-     // Config.getSpecificationsChangedObservable().subscribe(Bus.updateAllSpecificationsModbusAddresses)
+      // Config.getSpecificationsChangedObservable().subscribe(Bus.updateAllSpecificationsModbusAddresses)
     }
     return Bus.allSpecificationsModbusAddresses!
   }

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -62,7 +62,7 @@ export class Bus {
     }
   }
   static getBusses(): Bus[] {
-    if (!Bus.busses) {
+    if (!Bus.busses|| Bus.busses.length != ConfigBus.getBussesProperties().length) {
       Bus.readBussesFromConfig()
     }
     //debug("getBusses Number of busses:" + Bus.busses!.length)
@@ -72,12 +72,7 @@ export class Bus {
     debug('addBus()')
     let busP = ConfigBus.addBusProperties(connection)
     let b = Bus.getBusses().find((b) => b.getId() == busP.busId)
-    if (b) throw new Error('Unable to add Bus it exists')
-    else {
-      b = new Bus(busP)
-      Bus.getBusses().push(b)
-    }
-    return b
+    return b!
   }
   private connectionChanged(connection: IModbusConnection): boolean {
     let rtu = this.properties.connectionData as IRTUConnection

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -1,11 +1,6 @@
 import Debug from 'debug'
 import { Observable, Subject, first } from 'rxjs'
-import {
-  ImodbusEntity,
-  ImodbusSpecification,
-  ModbusRegisterType,
-  SpecificationStatus,
-} from '@modbus2mqtt/specification.shared'
+import { ImodbusEntity, ImodbusSpecification, ModbusRegisterType, SpecificationStatus } from '@modbus2mqtt/specification.shared'
 import { IdentifiedStates } from '@modbus2mqtt/specification.shared'
 import { Mutex } from 'async-mutex'
 import { ImodbusAddress, ModbusCache } from './modbuscache'
@@ -469,12 +464,9 @@ export class Bus {
       Bus.getBusses().forEach((bus) => {
         bus.getSlaves().forEach((slave) => {
           debug('updateAllSpecificationsModbusAddresses slaveid: ' + slave.slaveid)
-          if(specificationid == null )
-            slave.specificationid = undefined 
-          else
-            slave.specificationid = specificationid
-          if (slave.specificationid == specificationid)
-            cfg.writeslave(bus.getId(), slave)
+          if (specificationid == null) slave.specificationid = undefined
+          else slave.specificationid = specificationid
+          if (slave.specificationid == specificationid) cfg.writeslave(bus.getId(), slave)
         })
       })
     }
@@ -627,11 +619,11 @@ export class Bus {
     let entityIdentifications: ImodbusEntity[] = []
 
     for (let ent of spec.entities) {
-      let em:ImodbusEntity = structuredClone(ent as any)
-      em.modbusValue=  []
+      let em: ImodbusEntity = structuredClone(ent as any)
+      em.modbusValue = []
       em.mqttValue = ''
-      em.identified= IdentifiedStates.notIdentified
-      entityIdentifications.push( structuredClone(ent as any))
+      em.identified = IdentifiedStates.notIdentified
+      entityIdentifications.push(structuredClone(ent as any))
     }
 
     let configuredslave = this.properties.slaves.find((dev) => dev.specificationid === spec.filename && dev.slaveid == slaveid)
@@ -646,9 +638,7 @@ export class Bus {
     }
   }
 
-  writeSlave(
-    slave: Islave
-  ): Islave {
+  writeSlave(slave: Islave): Islave {
     if (slave.slaveid < 0) throw new Error('Try to save invalid slave id ') // Make sure slaveid is unique
     let oldIdx = this.properties.slaves.findIndex((dev) => {
       return dev.slaveid === slave.slaveid

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,7 +58,6 @@ export const filesUrlPrefix = 'specifications/files'
 //const baseTopic = 'modbus2mqtt';
 //const baseTopicHomeAssistant = 'homeassistant';
 export class Config {
-
   static tokenExpiryTime: number = defaultTokenExpiryTime
   static mqttHassioLoginData: ImqttClient | undefined = undefined
   static login(name: string, password: string): Promise<string> {

--- a/src/configbus.ts
+++ b/src/configbus.ts
@@ -1,41 +1,41 @@
-import { IBus, IModbusConnection, Islave, Slave } from "@modbus2mqtt/server.shared"
-import { ConfigSpecification, Logger, LogLevelEnum } from "@modbus2mqtt/specification"
-import { BUS_TIMEOUT_DEFAULT, IbaseSpecification } from "@modbus2mqtt/specification.shared"
+import { IBus, IModbusConnection, Islave, Slave } from '@modbus2mqtt/server.shared'
+import { ConfigSpecification, Logger, LogLevelEnum } from '@modbus2mqtt/specification'
+import { BUS_TIMEOUT_DEFAULT, IbaseSpecification } from '@modbus2mqtt/specification.shared'
 import { parse, stringify } from 'yaml'
 import * as fs from 'fs'
 import * as path from 'path'
 
 import Debug from 'debug'
-import { join } from "path"
-import { Config, ConfigListenerEvent } from "./config"
-import { MqttDiscover } from "./mqttdiscover"
-import { SerialPort } from "serialport/dist/serialport"
+import { join } from 'path'
+import { Config, ConfigListenerEvent } from './config'
+import { MqttDiscover } from './mqttdiscover'
+import { SerialPort } from 'serialport/dist/serialport'
 const log = new Logger('config')
 const debug = Debug('configbus')
 
-export class ConfigBus{
-    private static busses: IBus[]
-    private static listeners: { event: ConfigListenerEvent; listener: ((arg: Slave) => void) | ((arg: number) => void) }[] = []
-    static addListener(event: ConfigListenerEvent, listener: ((arg: Slave) => void) | ((arg: number) => void)) {
-      ConfigBus.listeners.push({ event: event, listener: listener })
-    }
-    private static emitSlaveEvent(event: ConfigListenerEvent, arg: Slave) {
-      let rc = MqttDiscover.addSpecificationToSlave(arg)
-      ConfigBus.listeners.forEach((eventListener) => {
-        if (eventListener.event == event) (eventListener.listener as (arg: Slave) => void)(rc)
-      })
-    }
-    private static emitBusEvent(event: ConfigListenerEvent, arg: number) {
-      ConfigBus.listeners.forEach((eventListener) => {
-        if (eventListener.event == event) (eventListener.listener as (arg: number) => void)(arg)
-      })
-    }
-  
-    static getBussesProperties(): IBus[] {
-        return ConfigBus.busses
-      }
-    
-static readBusses() {
+export class ConfigBus {
+  private static busses: IBus[]
+  private static listeners: { event: ConfigListenerEvent; listener: ((arg: Slave) => void) | ((arg: number) => void) }[] = []
+  static addListener(event: ConfigListenerEvent, listener: ((arg: Slave) => void) | ((arg: number) => void)) {
+    ConfigBus.listeners.push({ event: event, listener: listener })
+  }
+  private static emitSlaveEvent(event: ConfigListenerEvent, arg: Slave) {
+    let rc = MqttDiscover.addSpecificationToSlave(arg)
+    ConfigBus.listeners.forEach((eventListener) => {
+      if (eventListener.event == event) (eventListener.listener as (arg: Slave) => void)(rc)
+    })
+  }
+  private static emitBusEvent(event: ConfigListenerEvent, arg: number) {
+    ConfigBus.listeners.forEach((eventListener) => {
+      if (eventListener.event == event) (eventListener.listener as (arg: number) => void)(arg)
+    })
+  }
+
+  static getBussesProperties(): IBus[] {
+    return ConfigBus.busses
+  }
+
+  static readBusses() {
     ConfigBus.busses = []
     let busDir = Config.yamlDir + '/local/busses'
     let oneBusFound = false
@@ -69,7 +69,10 @@ static readBusses() {
                   })
                   var o: Islave = parse(src)
                   ConfigBus.busses[ConfigBus.busses.length - 1].slaves.push(o)
-                  ConfigBus.emitSlaveEvent(ConfigListenerEvent.addSlave, new Slave(busid, o, Config.getConfiguration().mqttbasetopic))
+                  ConfigBus.emitSlaveEvent(
+                    ConfigListenerEvent.addSlave,
+                    new Slave(busid, o, Config.getConfiguration().mqttbasetopic)
+                  )
                 }
               })
             } catch (e: any) {
@@ -116,12 +119,11 @@ static readBusses() {
     debug('config: busses.length: ' + ConfigBus.busses.length)
   }
 
-  getInstance():ConfigBus{
+  getInstance(): ConfigBus {
     ConfigBus.busses = ConfigBus.busses && ConfigBus.busses.length > 0 ? ConfigBus.busses : []
     return new ConfigBus()
   }
-  
-    
+
   static addBusProperties(connection: IModbusConnection): IBus {
     let maxBusId = -1
     ConfigBus.busses.forEach((b) => {
@@ -164,7 +166,7 @@ static readBusses() {
     }
   }
 
-  static async  filterAllslaves<T>(busid: number, specFunction: <T>(slave: Islave) => Set<T> | any): Promise<Set<T>> {
+  static async filterAllslaves<T>(busid: number, specFunction: <T>(slave: Islave) => Set<T> | any): Promise<Set<T>> {
     let addresses = new Set<T>()
     for (let slave of ConfigBus.busses[busid].slaves) {
       for (let addr of specFunction(slave)) addresses.add(addr)
@@ -233,8 +235,6 @@ static readBusses() {
     return rc
   }
 
-
-
   static deleteSlave(busid: number, slaveid: number) {
     let bus = ConfigBus.busses.find((bus) => bus.busId == busid)
     if (bus != undefined) {
@@ -299,7 +299,7 @@ static readBusses() {
       reject
     )
   }
-  
+
   static listDevices(next: (devices: string[]) => void, reject: (error: any) => void): void {
     try {
       ConfigBus.listDevicesHassio(next, (_e) => {
@@ -313,5 +313,4 @@ static readBusses() {
       }
     }
   }
-
 }

--- a/src/configbus.ts
+++ b/src/configbus.ts
@@ -130,6 +130,7 @@ export class ConfigBus {
       if (b.busId > maxBusId) maxBusId = b.busId
     })
     maxBusId++
+    log.log(LogLevelEnum.notice, "AddBusProperties: " + maxBusId)
     let busArrayIndex =
       ConfigBus.busses.push({
         busId: maxBusId,

--- a/src/configbus.ts
+++ b/src/configbus.ts
@@ -1,0 +1,317 @@
+import { IBus, IModbusConnection, Islave, Slave } from "@modbus2mqtt/server.shared"
+import { ConfigSpecification, Logger, LogLevelEnum } from "@modbus2mqtt/specification"
+import { BUS_TIMEOUT_DEFAULT, IbaseSpecification } from "@modbus2mqtt/specification.shared"
+import { parse, stringify } from 'yaml'
+import * as fs from 'fs'
+import * as path from 'path'
+
+import Debug from 'debug'
+import { join } from "path"
+import { Config, ConfigListenerEvent } from "./config"
+import { MqttDiscover } from "./mqttdiscover"
+import { SerialPort } from "serialport/dist/serialport"
+const log = new Logger('config')
+const debug = Debug('configbus')
+
+export class ConfigBus{
+    private static busses: IBus[]
+    private static listeners: { event: ConfigListenerEvent; listener: ((arg: Slave) => void) | ((arg: number) => void) }[] = []
+    static addListener(event: ConfigListenerEvent, listener: ((arg: Slave) => void) | ((arg: number) => void)) {
+      ConfigBus.listeners.push({ event: event, listener: listener })
+    }
+    private static emitSlaveEvent(event: ConfigListenerEvent, arg: Slave) {
+      let rc = MqttDiscover.addSpecificationToSlave(arg)
+      ConfigBus.listeners.forEach((eventListener) => {
+        if (eventListener.event == event) (eventListener.listener as (arg: Slave) => void)(rc)
+      })
+    }
+    private static emitBusEvent(event: ConfigListenerEvent, arg: number) {
+      ConfigBus.listeners.forEach((eventListener) => {
+        if (eventListener.event == event) (eventListener.listener as (arg: number) => void)(arg)
+      })
+    }
+  
+    static getBussesProperties(): IBus[] {
+        return ConfigBus.busses
+      }
+    
+static readBusses() {
+    ConfigBus.busses = []
+    let busDir = Config.yamlDir + '/local/busses'
+    let oneBusFound = false
+    if (fs.existsSync(busDir)) {
+      let busDirs: fs.Dirent[] = fs.readdirSync(busDir, {
+        withFileTypes: true,
+      })
+      busDirs.forEach((de) => {
+        if (de.isDirectory() && de.name.startsWith('bus.')) {
+          let busid = Number.parseInt(de.name.substring(4))
+          let busYaml = join(de.path, de.name, 'bus.yaml')
+          let connectionData: IModbusConnection
+          if (fs.existsSync(busYaml)) {
+            var src: string = fs.readFileSync(busYaml, {
+              encoding: 'utf8',
+            })
+            try {
+              connectionData = parse(src)
+              ConfigBus.busses.push({
+                busId: busid,
+                connectionData: connectionData,
+                slaves: [],
+              })
+              oneBusFound = true
+              let devFiles: string[] = fs.readdirSync(Config.yamlDir + '/local/busses/' + de.name)
+
+              devFiles.forEach(function (file: string) {
+                if (file.endsWith('.yaml') && file !== 'bus.yaml') {
+                  var src: string = fs.readFileSync(Config.yamlDir + '/local/busses/' + de.name + '/' + file, {
+                    encoding: 'utf8',
+                  })
+                  var o: Islave = parse(src)
+                  ConfigBus.busses[ConfigBus.busses.length - 1].slaves.push(o)
+                  ConfigBus.emitSlaveEvent(ConfigListenerEvent.addSlave, new Slave(busid, o, Config.getConfiguration().mqttbasetopic))
+                }
+              })
+            } catch (e: any) {
+              log.log(LogLevelEnum.error, 'Unable to parse bus os slave file: ' + busYaml + 'error:' + e.message)
+            }
+          }
+        }
+      })
+    }
+    if (!oneBusFound) {
+      this.listDevices(
+        (devices) => {
+          if (devices && devices.length) {
+            let usb = devices.find((dev) => dev.toLocaleLowerCase().indexOf('usb') >= 0)
+            if (usb)
+              ConfigBus.addBusProperties({
+                serialport: usb,
+                timeout: BUS_TIMEOUT_DEFAULT,
+                baudrate: 9600,
+              })
+            else
+              ConfigBus.addBusProperties({
+                serialport: devices[0],
+                timeout: BUS_TIMEOUT_DEFAULT,
+                baudrate: 9600,
+              })
+          } else
+            ConfigBus.addBusProperties({
+              serialport: '/dev/ttyACM0',
+              timeout: BUS_TIMEOUT_DEFAULT,
+              baudrate: 9600,
+            })
+        },
+        () => {
+          ConfigBus.addBusProperties({
+            serialport: '/dev/ttyACM0',
+            timeout: BUS_TIMEOUT_DEFAULT,
+            baudrate: 9600,
+          })
+        }
+      )
+    }
+
+    debug('config: busses.length: ' + ConfigBus.busses.length)
+  }
+
+  getInstance():ConfigBus{
+    ConfigBus.busses = ConfigBus.busses && ConfigBus.busses.length > 0 ? ConfigBus.busses : []
+    return new ConfigBus()
+  }
+  
+    
+  static addBusProperties(connection: IModbusConnection): IBus {
+    let maxBusId = -1
+    ConfigBus.busses.forEach((b) => {
+      if (b.busId > maxBusId) maxBusId = b.busId
+    })
+    maxBusId++
+    let busArrayIndex =
+      ConfigBus.busses.push({
+        busId: maxBusId,
+        connectionData: connection,
+        slaves: [],
+      }) - 1
+    let busDir = Config.yamlDir + '/local/busses/bus.' + maxBusId
+    if (!fs.existsSync(busDir)) {
+      fs.mkdirSync(busDir, { recursive: true })
+      debug('creating slaves path: ' + busDir)
+    }
+    let src = stringify(connection)
+    fs.writeFileSync(join(busDir, 'bus.yaml'), src, { encoding: 'utf8' })
+    return ConfigBus.busses[busArrayIndex]
+  }
+  static updateBusProperties(bus: IBus, connection: IModbusConnection): IBus {
+    bus.connectionData = connection
+    let busDir = Config.yamlDir + '/local/busses/bus.' + bus.busId
+    if (!fs.existsSync(busDir)) {
+      fs.mkdirSync(busDir, { recursive: true })
+      debug('creating slaves path: ' + busDir)
+    }
+    let src = stringify(connection)
+    fs.writeFileSync(join(busDir, 'bus.yaml'), src, { encoding: 'utf8' })
+    return bus
+  }
+  static deleteBusProperties(busid: number) {
+    let idx = ConfigBus.busses.findIndex((b) => b.busId == busid)
+    if (idx >= 0) {
+      ConfigBus.emitBusEvent(ConfigListenerEvent.deleteBus, busid)
+      let busDir = Config.yamlDir + '/local/busses/bus.' + busid
+      ConfigBus.busses.splice(idx, 1)
+      fs.rmSync(busDir, { recursive: true })
+    }
+  }
+
+  static async  filterAllslaves<T>(busid: number, specFunction: <T>(slave: Islave) => Set<T> | any): Promise<Set<T>> {
+    let addresses = new Set<T>()
+    for (let slave of ConfigBus.busses[busid].slaves) {
+      for (let addr of specFunction(slave)) addresses.add(addr)
+    }
+    return addresses
+  }
+  private static getslavePath(busid: number, slave: Islave): string {
+    return Config.yamlDir + '/local/busses/bus.' + busid + '/s' + slave.slaveid + '.yaml'
+  }
+  static writeslave(busid: number, slave: Islave): Islave {
+    // Make sure slaveid is unique
+    let oldFilePath = ConfigBus.getslavePath(busid, slave)
+    let filename = Config.getFileNameFromSlaveId(slave.slaveid)
+    let newFilePath = ConfigBus.getslavePath(busid, slave)
+    let dir = path.dirname(newFilePath)
+    if (!fs.existsSync(dir))
+      try {
+        fs.mkdirSync(dir, { recursive: true })
+      } catch (e) {
+        debug('Unable to create directory ' + dir + ' + e')
+        throw e
+      }
+    let o = structuredClone(slave)
+    for (var prop in o) {
+      if (Object.prototype.hasOwnProperty.call(o, prop)) {
+        let deletables: string[] = ['specification', 'durationOfLongestModbusCall', 'triggerPollTopic']
+        if (deletables.includes(prop)) delete (o as any)[prop]
+      }
+    }
+    let s = stringify(o)
+    fs.writeFileSync(newFilePath, s, { encoding: 'utf8' })
+    if (oldFilePath !== newFilePath && fs.existsSync(oldFilePath))
+      fs.unlink(oldFilePath, (err: any) => {
+        debug('writeslave: Unable to delete ' + oldFilePath + ' ' + err)
+      })
+
+    if (slave.specificationid) {
+      if (slave.specificationid == '_new') new ConfigSpecification().deleteNewSpecificationFiles()
+      else {
+        let spec = ConfigSpecification.getSpecificationByFilename(slave.specificationid)
+        slave.specification = spec as any as IbaseSpecification
+      }
+      ConfigBus.emitSlaveEvent(ConfigListenerEvent.updateSlave, new Slave(busid, slave, Config.getConfiguration().mqttbasetopic))
+    } else debug('No Specification found for slave: ' + filename + ' specification: ' + slave.specificationid)
+    return slave
+  }
+
+  static getSlave(busid: number, slaveid: number): Islave | undefined {
+    if (ConfigBus.busses.length <= busid) {
+      debug('Config.getslave: unknown bus')
+      return undefined
+    }
+    let rc = ConfigBus.busses[busid].slaves.find((dev) => {
+      return dev.slaveid === slaveid
+    })
+    if (!rc) debug('slaves.length: ' + ConfigBus.busses[busid].slaves.length)
+    for (let dev of ConfigBus.busses[busid].slaves) {
+      debug(dev.name)
+    }
+    return rc
+  }
+  static getslaveBySlaveId(busid: number, slaveId: number) {
+    let rc = ConfigBus.busses[busid].slaves.find((dev) => {
+      return dev.slaveid === slaveId
+    })
+    return rc
+  }
+
+
+
+  static deleteSlave(busid: number, slaveid: number) {
+    let bus = ConfigBus.busses.find((bus) => bus.busId == busid)
+    if (bus != undefined) {
+      debug('DELETE /slave slaveid' + busid + '/' + slaveid + ' number of slaves: ' + bus.slaves.length)
+      let found = false
+      for (let idx = 0; idx < bus.slaves.length; idx++) {
+        let dev = bus.slaves[idx]
+
+        if (dev.slaveid === slaveid) {
+          found = true
+          if (fs.existsSync(ConfigBus.getslavePath(busid, dev)))
+            fs.unlink(ConfigBus.getslavePath(busid, dev), (err) => {
+              if (err) debug(err)
+            })
+          ConfigBus.emitSlaveEvent(ConfigListenerEvent.deleteSlave, new Slave(busid, dev, Config.getConfiguration().mqttbasetopic))
+          bus.slaves.splice(idx, 1)
+          debug('DELETE /slave finished ' + slaveid + ' number of slaves: ' + bus.slaves.length)
+          return
+        }
+      }
+      if (!found) debug('slave not found for deletion ' + slaveid)
+    } else {
+      let msg = 'Unable to delete slave. Check server log for details'
+      log.log(LogLevelEnum.error, msg + ' busid ' + busid + ' not found')
+
+      throw new Error(msg)
+    }
+  }
+  private static listDevicesUdev(next: (devices: string[]) => void, reject: (error: any) => void): void {
+    SerialPort.list()
+      .then((portInfo) => {
+        let devices: string[] = []
+        portInfo.forEach((port) => {
+          devices.push(port.path)
+        })
+        next(devices)
+      })
+      .catch((error) => {
+        reject(error)
+      })
+  }
+  private static grepDevices(bodyObject: any): string[] {
+    var devices: any[] = bodyObject.data.devices
+    var rc: string[] = []
+    devices.forEach((device) => {
+      if (device.subsystem === 'tty')
+        try {
+          fs.accessSync(device.dev_path, fs.constants.R_OK)
+          rc.push(device.dev_path)
+        } catch (error) {
+          log.log(LogLevelEnum.error, 'Permission denied for read serial device %s', device.dev_path)
+        }
+    })
+    return rc
+  }
+  private static listDevicesHassio(next: (devices: string[]) => void, reject: (error: any) => void): void {
+    Config.executeHassioGetRequest<string[]>(
+      '/hardware/info',
+      (dev) => {
+        next(ConfigBus.grepDevices(dev))
+      },
+      reject
+    )
+  }
+  
+  static listDevices(next: (devices: string[]) => void, reject: (error: any) => void): void {
+    try {
+      ConfigBus.listDevicesHassio(next, (_e) => {
+        this.listDevicesUdev(next, reject)
+      })
+    } catch (e) {
+      try {
+        this.listDevicesUdev(next, reject)
+      } catch (e) {
+        next([])
+      }
+    }
+  }
+
+}

--- a/src/httpServerBase.ts
+++ b/src/httpServerBase.ts
@@ -261,6 +261,7 @@ export class HttpServerBase {
     this.app.use(bodyparser.json())
     this.app.use(bodyparser.urlencoded({ extended: true }))
     this.app.use(express.json())
+    this.app.use(this.processStaticAngularFiles.bind(this))
     //@ts-ignore
     this.app.use(function (_undefined: any, res: http.ServerResponse, next: any) {
       //            res.setHeader('charset', 'utf-8')
@@ -275,7 +276,6 @@ export class HttpServerBase {
     })
     // angular files have full path including language e.G. /en-US/polyfill.js
     this.app.use(this.authenticate.bind(this))
-    this.app.use(this.processStaticAngularFiles.bind(this))
     this.app.use(express.static(this.angulardir))
     this.app.get('/', (req: Request, res: express.Response, next: NextFunction) => {
       res.redirect('index.html')

--- a/src/httpServerBase.ts
+++ b/src/httpServerBase.ts
@@ -128,8 +128,8 @@ export class HttpServerBase {
     if (token != undefined) req.url = req.url.replace(token + '/', '')
     else token = HttpServerBase.getAuthTokenFromHeader(req)
     if (req.url.indexOf('/api/') >= 0 || req.url.indexOf('/user/register') >= 0 || req.url.indexOf('/download/') >= 0) {
-      let config = Config.getConfiguration()
-      if (config.hassiotoken) {
+      let authStatus = Config.getAuthStatus()
+      if (authStatus.hassiotoken) {
         let address = (req.socket.address() as AddressInfo).address
         if (
           !address ||
@@ -177,7 +177,7 @@ export class HttpServerBase {
     return new Promise<void>((resolve, reject) => {
       try {
         Config.executeHassioGetRequest<{ data: IAddonInfo }>(
-          'http://'+ Config.getConfiguration().supervisor_host + '/addons/self/info',
+          '/addons/self/info',
           (info) => {
             //this.ingressUrl = join("/hassio/ingress/", info.data.slug);
             this.ingressUrl = info.data.ingress_entry

--- a/src/httpserver.ts
+++ b/src/httpserver.ts
@@ -595,9 +595,10 @@ export class HttpServer extends HttpServerBase {
           if (req.body) {
             // req.body.documents
             let config = new ConfigSpecification()
-            let files = config.appendSpecificationUrl(req.query.specification!, req.body)
-            if (files) this.returnResult(req, res, HttpErrorsEnum.OkCreated, JSON.stringify(files))
-            else this.returnResult(req, res, HttpErrorsEnum.ErrBadRequest, ' specification not found')
+            config.appendSpecificationUrls(req.query.specification!, [req.body]).then(files=>{
+              if (files) this.returnResult(req, res, HttpErrorsEnum.OkCreated, JSON.stringify(files))
+                else this.returnResult(req, res, HttpErrorsEnum.ErrBadRequest, ' specification not found')    
+            })
           } else {
             this.returnResult(req, res, HttpErrorsEnum.ErrBadRequest, ' specification not found')
           }
@@ -625,13 +626,13 @@ export class HttpServer extends HttpServerBase {
           debug('Files uploaded')
           if (req.files) {
             // req.body.documents
-            let config = new ConfigSpecification()
-            let files: IimageAndDocumentUrl[] | undefined
-            ;(req.files as Express.Multer.File[])!.forEach((f) => {
-              files = config.appendSpecificationFile(req.query.specification!, f.originalname, req.query.usage!)
-            })
-            if (files) this.returnResult(req, res, HttpErrorsEnum.OkCreated, JSON.stringify(files))
-            else this.returnResult(req, res, HttpErrorsEnum.OkNoContent, ' specification not found or no files passed')
+            let config = new ConfigSpecification();
+            let f:string[] = [];
+            (req.files as Express.Multer.File[])!.forEach((f0:any) => {f.push(f0.originalname)});
+            config.appendSpecificationFiles(req.query.specification!, f, req.query.usage!).then(files=>{
+                if (files) this.returnResult(req, res, HttpErrorsEnum.OkCreated, JSON.stringify(files))
+                  else this.returnResult(req, res, HttpErrorsEnum.OkNoContent, ' specification not found or no files passed')      
+              })
           } else {
             this.returnResult(req, res, HttpErrorsEnum.OkNoContent, ' specification not found or no files passed')
           }

--- a/src/httpserver.ts
+++ b/src/httpserver.ts
@@ -29,6 +29,7 @@ import { ConfigSpecification } from '@modbus2mqtt/specification'
 import { HttpServerBase } from './httpServerBase'
 import { MqttDiscover } from './mqttdiscover'
 import { Writable } from 'stream'
+import { ConfigBus } from './configbus'
 const debug = Debug('httpserver')
 const log = new Logger('httpserver')
 // import cors from 'cors';
@@ -493,7 +494,7 @@ export class HttpServer extends HttpServerBase {
     this.get(apiUri.serialDevices, (req: GetRequestWithParameter, res: http.ServerResponse) => {
       debug(req.url)
 
-      Config.listDevices(
+      ConfigBus.listDevices(
         (devices) => {
           this.returnResult(req, res, HttpErrorsEnum.OK, JSON.stringify(devices))
         },
@@ -522,7 +523,7 @@ export class HttpServer extends HttpServerBase {
         (filename: string) => {
           if (bus != undefined && slave != undefined) {
             slave.specificationid = filename
-            new Config().writeslave(bus.getId(), slave)
+            ConfigBus.writeslave(bus.getId(), slave)
           }
         },
         originalFilename

--- a/src/modbus.ts
+++ b/src/modbus.ts
@@ -18,7 +18,14 @@ export class Modbus {
 
   writeEntityModbus(bus: Bus, slaveid: number, entity: Ientity, modbusValue: ReadRegisterResult): Promise<void> {
     // this.modbusClient.setID(device.slaveid);
-    if (entity.modbusAddress && entity.registerType) {
+    if(Config.getConfiguration().fakeModbus)
+    {
+      return new Promise<void>((resolve)=>{
+        debug( "Fake ModbusWrite")
+        resolve()
+      })
+    }
+    else if (entity.modbusAddress && entity.registerType) {
       return new ModbusCache('write', true).writeRegisters(
         { busid: bus.getId(), slaveid: slaveid },
         entity.modbusAddress,
@@ -32,7 +39,14 @@ export class Modbus {
   writeEntityMqtt(bus: Bus, slaveid: number, spec: Ispecification, entityid: number, mqttValue: string): Promise<void> {
     // this.modbusClient.setID(device.slaveid);
     let entity = spec.entities.find((ent) => ent.id == entityid)
-    if (entity) {
+    if(Config.getConfiguration().fakeModbus)
+      {
+        return new Promise<void>((resolve)=>{
+          debug( "Fake ModbusWrite")
+          resolve()
+        })
+      }
+    else if (entity) {
       let converter = ConverterMap.getConverter(entity)
       if (entity.modbusAddress && entity.registerType && converter) {
         let modbusValue = converter?.mqtt2modbus(spec, entityid, mqttValue)

--- a/src/modbus.ts
+++ b/src/modbus.ts
@@ -18,14 +18,12 @@ export class Modbus {
 
   writeEntityModbus(bus: Bus, slaveid: number, entity: Ientity, modbusValue: ReadRegisterResult): Promise<void> {
     // this.modbusClient.setID(device.slaveid);
-    if(Config.getConfiguration().fakeModbus)
-    {
-      return new Promise<void>((resolve)=>{
-        debug( "Fake ModbusWrite")
+    if (Config.getConfiguration().fakeModbus) {
+      return new Promise<void>((resolve) => {
+        debug('Fake ModbusWrite')
         resolve()
       })
-    }
-    else if (entity.modbusAddress && entity.registerType) {
+    } else if (entity.modbusAddress && entity.registerType) {
       return new ModbusCache('write', true).writeRegisters(
         { busid: bus.getId(), slaveid: slaveid },
         entity.modbusAddress,
@@ -39,14 +37,12 @@ export class Modbus {
   writeEntityMqtt(bus: Bus, slaveid: number, spec: Ispecification, entityid: number, mqttValue: string): Promise<void> {
     // this.modbusClient.setID(device.slaveid);
     let entity = spec.entities.find((ent) => ent.id == entityid)
-    if(Config.getConfiguration().fakeModbus)
-      {
-        return new Promise<void>((resolve)=>{
-          debug( "Fake ModbusWrite")
-          resolve()
-        })
-      }
-    else if (entity) {
+    if (Config.getConfiguration().fakeModbus) {
+      return new Promise<void>((resolve) => {
+        debug('Fake ModbusWrite')
+        resolve()
+      })
+    } else if (entity) {
       let converter = ConverterMap.getConverter(entity)
       if (entity.modbusAddress && entity.registerType && converter) {
         let modbusValue = converter?.mqtt2modbus(spec, entityid, mqttValue)

--- a/src/modbus2mqtt.ts
+++ b/src/modbus2mqtt.ts
@@ -102,6 +102,7 @@ export class Modbus2Mqtt {
         debugAction('readBussesFromConfig starts')
         gh.init()
           .then(() => {
+            let md = MqttDiscover.getInstance()
             ConfigBus.readBusses()
             this.pollTasks()
             debugAction('readBussesFromConfig done')
@@ -119,7 +120,6 @@ export class Modbus2Mqtt {
                 new ConfigSpecification().deleteNewSpecificationFiles()
                 Bus.getAllAvailableModusData()
                 if (process.env.MODBUS_NOPOLL == undefined) {
-                  let md = MqttDiscover.getInstance()
                   md.startPolling()
                 } else {
                   log.log(LogLevelEnum.notice, 'Poll disabled by environment variable MODBUS_POLL')

--- a/src/modbus2mqtt.ts
+++ b/src/modbus2mqtt.ts
@@ -12,6 +12,7 @@ import { ConfigSpecification } from '@modbus2mqtt/specification'
 import path, { dirname, join } from 'path'
 import { SpecificationStatus } from '@modbus2mqtt/specification.shared'
 import * as fs from 'fs'
+import { ConfigBus } from './configbus'
 const { argv } = require('node:process')
 
 process.on('unhandledRejection', (reason, p) => {
@@ -101,6 +102,7 @@ export class Modbus2Mqtt {
         debugAction('readBussesFromConfig starts')
         gh.init()
           .then(() => {
+            ConfigBus.readBusses()
             this.pollTasks()
             debugAction('readBussesFromConfig done')
             debug('Inititialize busses done')

--- a/src/modbus2mqtt.ts
+++ b/src/modbus2mqtt.ts
@@ -113,23 +113,24 @@ export class Modbus2Mqtt {
               },
               30 * 1000 * 60
             )
+            httpServer.init().then(() => {
+              httpServer.app.listen(Config.getConfiguration().httpport, () => {
+                log.log(LogLevelEnum.notice, `modbus2mqtt listening on  ${os.hostname()}: ${Config.getConfiguration().httpport}`)
+                new ConfigSpecification().deleteNewSpecificationFiles()
+                Bus.getAllAvailableModusData()
+                if (process.env.MODBUS_NOPOLL == undefined) {
+                  let md = MqttDiscover.getInstance()
+                  md.startPolling()
+                } else {
+                  log.log(LogLevelEnum.notice, 'Poll disabled by environment variable MODBUS_POLL')
+                }
+              })
+            })
+    
           })
           .catch((e) => {
             log.log(LogLevelEnum.error, 'Start polling Contributions: ' + e.message)
           })
-        httpServer.init().then(() => {
-          httpServer.app.listen(Config.getConfiguration().httpport, () => {
-            log.log(LogLevelEnum.notice, `modbus2mqtt listening on  ${os.hostname()}: ${Config.getConfiguration().httpport}`)
-            new ConfigSpecification().deleteNewSpecificationFiles()
-            Bus.getAllAvailableModusData()
-            if (process.env.MODBUS_NOPOLL == undefined) {
-              let md = MqttDiscover.getInstance()
-              md.startPolling()
-            } else {
-              log.log(LogLevelEnum.notice, 'Poll disabled by environment variable MODBUS_POLL')
-            }
-          })
-        })
       })
   }
 }

--- a/src/mqttdiscover.ts
+++ b/src/mqttdiscover.ts
@@ -558,19 +558,7 @@ export class MqttDiscover {
       })
     })
   }
-  static addTopicAndPayloads(spec: ImodbusSpecification, busid: number, slave: Islave): void {
-    let hasWritableEntities = spec.entities.find((e) => !e.readonly)
-    spec.entities.forEach((ent) => {
-      if (!ent.readonly) ent.commandTopic = MqttDiscover.generateEntityCommandTopic(busid, slave, ent)
-      let cv = ConverterMap.getConverter(ent)
-      if (cv && cv.publishModbusValues()) {
-        ent.commandTopicModbus = ent.commandTopic + '/' + modbusValues
-      }
-    })
-    spec.stateTopic = MqttDiscover.generateStateTopic(busid, slave)
-    spec.statePayload = MqttDiscover.generateStatePayload(busid, slave, spec)
-    spec.triggerPollTopic = MqttDiscover.generateTriggerPollTopic(busid, slave)
-  }
+
   static generateStatePayload(busid: number, slave: Islave, spec: ImodbusSpecification): string {
     let o: any = {}
     for (let e of spec.entities) {

--- a/src/mqttdiscover.ts
+++ b/src/mqttdiscover.ts
@@ -608,9 +608,10 @@ export class MqttDiscover {
             if (slave.specification) {
               needPolls.push({ slave: s, pollMode: trigger == undefined ? PollModes.intervall : PollModes.trigger })
             } else {
-              log.log(
-                LogLevelEnum.error,
-                'No specification found for slave ' + s.getSlaveId() + ' specid: ' + s.getSpecificationId()
+              if( slave.specificationid )
+                log.log(
+                  LogLevelEnum.error,
+                    'No specification found for slave ' + s.getSlaveId() + ' specid: ' + s.getSpecificationId()
               )
             }
           }

--- a/src/mqttdiscover.ts
+++ b/src/mqttdiscover.ts
@@ -133,9 +133,6 @@ export class MqttDiscover {
       '/config'
     )
   }
-  private getSlavesConfigurationTopic(): string {
-    return Config.getConfiguration().mqttdiscoveryprefix + '/+/+/+/config'
-  }
   private generateDiscoveryPayloads(slave: Slave, spec: ImodbusSpecification): ItopicAndPayloads[] {
     let payloads: { topic: string; payload: string }[] = []
     // instantiate the converters


### PR DESCRIPTION
Fixes:

 - Set Unit of measurement according to device class. Closes #62
 - Set Quality of service for a slave. Closes #61 
    - For command topics it's important to get the message. This can be achieved by setting QoS
      There is a QoS named Auto. It will set QOS to 1 if the slave has a writable entity. Otherwise it is 0 (sensors)
 - MQTT Discovery: 
     - Send MQTT discovery when changing the slave (or specification)
     - Send State update after receiving a command (topic)
 - Add debug information from MQTT Client  in log file using debug prefix "mqttclient"

Features:
  - MQTT discovery: You can now specify a own MQTT prefix for each modbus slave (E.g. heatpump/...)
    This will affect the command, the state and the trigger topics of all entities of the slave. 
 
Development:
  . Add Cypress test for creation  of a specification.