### PR TITLE
root Topic, web service, precision, MQTT Discovery fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "args": [  "-s", "../ssl", "-y" ,"../yaml-dir"],
       "console": "integratedTerminal",
       "env": {
-        "DEBUG": "mqttdiscover",
+        "DEBUG": "",
         "NODE_OPTIONS": "--experimental-vm-modules npx jest"
       },
       "request": "launch",
@@ -113,7 +113,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "env": {
-        "DEBUG": "bus.mutex",
+        "DEBUG": "httpserver",
         "NODE_OPTIONS": "--experimental-vm-modules npx jest"
       },
       "args": [

--- a/__tests__/configsbase.ts
+++ b/__tests__/configsbase.ts
@@ -18,13 +18,13 @@ export class FakeMqtt {
   disconnected = false
   connected = true
   isAsExcpected = false
-  options:ImqttClient ={
-    protocol: "mqtt",
-    host: "doesnt_exist",
+  options: ImqttClient = {
+    protocol: 'mqtt',
+    host: 'doesnt_exist',
     port: 1007,
-    username: "modbus2mqtt",
-    password: "modbus2mqtt"
-   }
+    username: 'modbus2mqtt',
+    password: 'modbus2mqtt',
+  }
   constructor(
     protected md: MqttDiscover,
     public fakeMode: FakeModes
@@ -54,7 +54,7 @@ export class FakeMqtt {
       debug('publish: ' + topic + '\n' + message)
     }
   }
-  public end(endFunc:()=>void) {
+  public end(endFunc: () => void) {
     endFunc()
     debug('end')
   }

--- a/__tests__/configsbase.ts
+++ b/__tests__/configsbase.ts
@@ -54,7 +54,8 @@ export class FakeMqtt {
       debug('publish: ' + topic + '\n' + message)
     }
   }
-  public end() {
+  public end(endFunc:()=>void) {
+    endFunc()
     debug('end')
   }
   public on(event: 'message', cb: () => {}) {}

--- a/__tests__/configsbase.ts
+++ b/__tests__/configsbase.ts
@@ -3,6 +3,7 @@ import { MqttDiscover } from '../src/mqttdiscover'
 import Debug from 'debug'
 import exp from 'constants'
 import { Config } from '../src/config'
+import { ImqttClient } from '@modbus2mqtt/server.shared'
 
 export const yamlDir = '__tests__/yaml-dir'
 export let singleMutex = new Mutex()
@@ -17,6 +18,13 @@ export class FakeMqtt {
   disconnected = false
   connected = true
   isAsExcpected = false
+  options:ImqttClient ={
+    protocol: "mqtt",
+    host: "doesnt_exist",
+    port: 1007,
+    username: "modbus2mqtt",
+    password: "modbus2mqtt"
+   }
   constructor(
     protected md: MqttDiscover,
     public fakeMode: FakeModes

--- a/__tests__/httpserver_slaveservice.tsx
+++ b/__tests__/httpserver_slaveservice.tsx
@@ -91,14 +91,18 @@ class MockMqttDiscover {
     }
     return undefined
   }
-  sendEntityCommand(_slave: Slave, topic:string, payload: string): Promise<void> {
-    expect( topic.startsWith("/")).toBeFalsy()
-    expect(payload).toBe("20.2")
-    return new Promise<void>((resolve=>{resolve()}))
+  sendEntityCommandWithPublish(_slave: Slave, topic: string, payload: string): Promise<void> {
+    expect(topic.startsWith('/')).toBeFalsy()
+    expect(payload).toBe('20.2')
+    return new Promise<void>((resolve) => {
+      resolve()
+    })
   }
-  sendCommand( _slave: Slave, payload: string): Promise<void> {
-    expect(payload.indexOf("20.2")).not.toBe(-1)
-    return new Promise<void>((resolve=>{resolve()}))
+  sendCommand(_slave: Slave, payload: string): Promise<void> {
+    expect(payload.indexOf('20.2')).not.toBe(-1)
+    return new Promise<void>((resolve) => {
+      resolve()
+    })
   }
 }
 function prepareMqttDiscover(): MockMqttDiscover {
@@ -113,7 +117,7 @@ it('GET state topic', (done) => {
     .get('/' + mockDiscover.slave.getStateTopic())
     .expect(200)
     .then((response) => {
-      expect(response.text.indexOf("waterleveltransmitter")).not.toBe(-1)
+      expect(response.text.indexOf('waterleveltransmitter')).not.toBe(-1)
       done()
     })
     .catch((e) => {
@@ -124,27 +128,26 @@ it('GET state topic', (done) => {
 
 test('GET command Entity topic', (done) => {
   let mockDiscover = prepareMqttDiscover()
-  let url = '/' + mockDiscover.slave.getEntityCommandTopic( mockDiscover.slave.getSpecification()!.entities[2])!.commandTopic
-  url = url + "20.2"
+  let url = '/' + mockDiscover.slave.getEntityCommandTopic(mockDiscover.slave.getSpecification()!.entities[2])!.commandTopic
+  url = url + '20.2'
   supertest(httpServer.app)
     .get(url)
     //.send("{hotwatertargettemperature: 20.2}")
-   // .send("20.2")
+    // .send("20.2")
     .expect(200)
     .then(() => {
       done()
     })
-  })
-  test('POST command topic', (done) => {
-      let mockDiscover = prepareMqttDiscover()
-      let url = '/' + mockDiscover.slave.getCommandTopic()
-       supertest(httpServer.app)
-        .post(url)
-        .send({ "hotwatertargettemperature" : 20.2 })
-       // .send("20.2")
-        .expect(200)
-        .then(() => {
-          done()
-        })
-      })
-
+})
+test('POST command topic', (done) => {
+  let mockDiscover = prepareMqttDiscover()
+  let url = '/' + mockDiscover.slave.getCommandTopic()
+  supertest(httpServer.app)
+    .post(url)
+    .send({ hotwatertargettemperature: 20.2 })
+    // .send("20.2")
+    .expect(200)
+    .then(() => {
+      done()
+    })
+})

--- a/__tests__/httpserver_slaveservice.tsx
+++ b/__tests__/httpserver_slaveservice.tsx
@@ -1,0 +1,158 @@
+import { expect, it, test, jest, beforeAll } from '@jest/globals'
+import Debug from 'debug'
+import { HttpServer as HttpServer } from '../src/httpserver'
+import { Config } from '../src/config'
+import supertest from 'supertest'
+import { Ientity, ImodbusSpecification } from '@modbus2mqtt/specification.shared'
+import { ModbusCache } from '../src/modbuscache'
+import { submitGetHoldingRegisterRequest } from '../src/submitRequestMock'
+import { Bus } from '../src/bus'
+import { Slave } from '@modbus2mqtt/server.shared'
+import { LogLevelEnum, Logger } from '@modbus2mqtt/specification'
+import { ConfigSpecification } from '@modbus2mqtt/specification'
+import { join } from 'path'
+import { MqttDiscover } from '../src/mqttdiscover'
+import { ConfigBus } from '../src/configbus'
+import { Observable, Subject } from 'rxjs'
+let mockReject = false
+let debug = Debug('testhttpserver')
+const mqttService = {
+  host: 'core-mosquitto',
+  port: 1883,
+  ssl: false,
+  protocol: '3.1.1',
+  username: 'addons',
+  password: 'Euso6ahphaiWei9Aeli6Tei0si2paep5agethohboophe7vae9uc0iebeezohg8e',
+  addon: 'core_mosquitto',
+  ingress_entry: 'test',
+}
+function executeHassioGetRequest<T>(_url: string, next: (_dev: T) => void, reject: (error: any) => void): void {
+  if (mockReject) reject('mockedReason')
+  else next({ data: mqttService } as T)
+}
+
+let log = new Logger('httpserverTest')
+const yamlDir = '__tests__/yaml-dir'
+ConfigSpecification.yamlDir = yamlDir
+new ConfigSpecification().readYaml()
+Config.sslDir = yamlDir
+Config['executeHassioGetRequest'] = executeHassioGetRequest
+
+var httpServer: HttpServer
+
+function mockedAuthorization(_param: any): Promise<any> {
+  return new Promise<any>((resolve) => {
+    resolve({ justForTesting: true })
+  })
+}
+function mockedHttp(_options: any, cb: (res: any) => any) {
+  cb({ statusCode: 200 })
+}
+let oldExecuteHassioGetRequest: any
+const oldAuthenticate: (req: any, res: any, next: () => void) => void = HttpServer.prototype.authenticate
+beforeAll(() => {
+  return new Promise<void>((resolve, reject) => {
+    Config['yamlDir'] = yamlDir
+    let cfg = new Config()
+    cfg.readYamlAsync().then(() => {
+      ConfigBus.readBusses()
+      ;(Config as any)['fakeModbusCache'] = true
+      jest.mock('../src/modbus')
+      ModbusCache.prototype.submitGetHoldingRegisterRequest = submitGetHoldingRegisterRequest
+      HttpServer.prototype.authenticate = (req, res, next) => {
+        next()
+      }
+      httpServer = new HttpServer(join(yamlDir, 'angular'))
+
+      httpServer.setModbusCacheAvailable()
+      httpServer.init()
+      oldExecuteHassioGetRequest = Config['executeHassioGetRequest']
+      resolve()
+    })
+  })
+})
+
+class MockMqttDiscover {
+  slave: Slave = new Slave(0, Bus.getBus(0)!.getSlaveBySlaveId(1)!, Config.getConfiguration().mqttbasetopic)
+  getSlave(url: string): Slave | undefined {
+    return this.slave
+  }
+  readModbus(slave: Slave): Observable<ImodbusSpecification> | undefined {
+    let bus = Bus.getBus(slave.getBusId())
+    if (bus) {
+      let sub = new Subject<ImodbusSpecification>()
+      let f = async function (sub: Subject<ImodbusSpecification>) {
+        setTimeout(() => {
+          sub.next(slave.getSpecification() as ImodbusSpecification)
+        }, 20)
+      }
+      f(sub)
+      return sub
+    }
+    return undefined
+  }
+  sendCommand(_slave: Slave, topic:string, payload: string): Promise<void> {
+    expect( topic.startsWith("/")).toBeFalsy()
+    expect(payload).toBe("20.2")
+    return new Promise<void>((resolve=>{resolve()}))
+  }
+}
+function prepareMqttDiscover(): MockMqttDiscover {
+  let mockDiscover = new MockMqttDiscover()
+  MqttDiscover['instance'] = mockDiscover as any as MqttDiscover
+  return mockDiscover
+}
+it('GET state topic', (done) => {
+  let mockDiscover = prepareMqttDiscover()
+
+  supertest(httpServer.app)
+    .get('/' + mockDiscover.slave.getStateTopic())
+    .expect(200)
+    .then((response) => {
+      expect(response.body.waterleveltransmitter).toBeGreaterThan(0)
+      done()
+    })
+    .catch((e) => {
+      log.log(LogLevelEnum.error, 'error')
+      expect(1).toBeFalsy()
+    })
+})
+
+test('POST command topic', (done) => {
+  let mockDiscover = prepareMqttDiscover()
+  let url = '/' + mockDiscover.slave.getEntityCommandTopic( mockDiscover.slave.getSpecification()!.entities[2])!.commandTopic
+  url = url + "20.2"
+  supertest(httpServer.app)
+    .get(url)
+    .send("20.2")
+    .expect(200)
+    .then(() => {
+      done()
+    })
+
+  // let newConn: IModbusConnection = {
+  //   baudrate: 9600,
+  //   serialport: '/dev/ttyACM1',
+  //   timeout: 200,
+  // }
+  // Bus.readBussesFromConfig()
+  // let oldLength = Bus.getBusses().length
+
+  // supertest(httpServer.app)
+  //   .post('/api/bus')
+  //   .accept('application/json')
+  //   .send(newConn)
+  //   .set('Content-Type', 'application/json')
+  //   .expect(201)
+  //   .then((response) => {
+  //     expect(Bus.getBusses().length).toBe(oldLength + 1)
+  //     let newNumber = response.body
+  //     supertest(httpServer.app)
+  //       .delete('/api/bus?busid=' + newNumber.busid)
+  //       .then((_response) => {
+  //         expect(200)
+  //         expect(Bus.getBusses().length).toBe(oldLength)
+  //         done()
+  //       })
+  //   })
+})

--- a/__tests__/httpserver_test.tsx
+++ b/__tests__/httpserver_test.tsx
@@ -143,10 +143,10 @@ beforeAll(() => {
       HttpServer.prototype.authenticate = (req, res, next) => {
         next()
       }
-      let  mdl = MqttDiscover.getInstance()
+      let mdl = MqttDiscover.getInstance()
       let fake = new FakeMqtt(mdl, FakeModes.Poll)
       mdl['client'] = fake as any as MqttClient
-      
+
       httpServer = new HttpServer(join(yamlDir, 'angular'))
 
       httpServer.setModbusCacheAvailable()

--- a/__tests__/httpserver_test.tsx
+++ b/__tests__/httpserver_test.tsx
@@ -143,6 +143,10 @@ beforeAll(() => {
       HttpServer.prototype.authenticate = (req, res, next) => {
         next()
       }
+      let  mdl = MqttDiscover.getInstance()
+      let fake = new FakeMqtt(mdl, FakeModes.Poll)
+      mdl['client'] = fake as any as MqttClient
+      
       httpServer = new HttpServer(join(yamlDir, 'angular'))
 
       httpServer.setModbusCacheAvailable()

--- a/__tests__/httpserver_test.tsx
+++ b/__tests__/httpserver_test.tsx
@@ -128,7 +128,7 @@ function mockedHttp(_options: any, cb: (res: any) => any) {
 }
 let oldExecuteHassioGetRequest: any
 let lspec = yamlDir + '/local/specifications/'
-  
+
 const oldAuthenticate: (req: any, res: any, next: () => void) => void = HttpServer.prototype.authenticate
 beforeAll(() => {
   return new Promise<void>((resolve, reject) => {
@@ -438,11 +438,8 @@ describe('http POST', () => {
   afterAll(() => {
     // Cleanup
     if (fs.existsSync(testdir + test1)) fs.unlinkSync(testdir + test1)
-    
-      
-    if( fs.existsSync(lspec + 'waterleveltransmitter.bck'))
-      fs.unlinkSync(lspec + 'waterleveltransmitter.bck')
- 
+
+    if (fs.existsSync(lspec + 'waterleveltransmitter.bck')) fs.unlinkSync(lspec + 'waterleveltransmitter.bck')
   })
 
   test('POST /specification: add new Specification rename device.specification', (done) => {
@@ -454,7 +451,7 @@ describe('http POST', () => {
       onConnected()
     }
     let spec1: ImodbusSpecification = Object.assign(spec)
-  
+
     let filename = yamlDir + '/local/specifications/waterleveltransmitter.yaml'
     fs.unlinkSync(ConfigSpecification['getSpecificationPath'](spec1))
     let url = apiUri.specfication + '?busid=0&slaveid=2&originalFilename=waterleveltransmitter'
@@ -564,7 +561,7 @@ describe('http POST', () => {
           expect(fs.existsSync(testdir + test1)).toBeTruthy()
           fs.unlinkSync(testdir + test1)
           fs.copyFileSync(lspec + 'waterleveltransmitter.bck', lspec + 'waterleveltransmitter.yaml', undefined)
-           supertest(httpServer.app)
+          supertest(httpServer.app)
             .delete(
               '/api/upload?specification=waterleveltransmitter&url=/files/waterleveltransmitter/' +
                 testPdf +

--- a/__tests__/modbus_test.tsx
+++ b/__tests__/modbus_test.tsx
@@ -341,8 +341,7 @@ it('Modbus writeEntityMqtt', (done) => {
   let dev = ConfigBus.getSlave(0, 1)!
   expect(dev).toBeDefined
 
-  new Modbus()
-    .writeEntityMqtt(Bus.getBus(0)!, 1, spec, 3, 'test')
+  Modbus.writeEntityMqtt(Bus.getBus(0)!, 1, spec, 3, 'test')
     .catch((e) => {
       expect(`[FAIL] ${e}`.trim()).toBeFalsy()
     })

--- a/__tests__/mqttdiscover_test.tsx
+++ b/__tests__/mqttdiscover_test.tsx
@@ -429,9 +429,9 @@ test('onMessage SendCommandTopic from this app', (done) => {
   let slave = structuredClone(bus!.getSlaveBySlaveId(1))
   slave!.specification = ConfigSpecification.getSpecificationByFilename(slave!.specificationid!)
   let sl = new Slave(0, slave!, Config.getConfiguration().mqttbasetopic)
-  ;(slave!.specification! as Ispecification).entities[0].readonly = false
+  ;(slave!.specification! as Ispecification).entities[2].readonly = false
   mdl['onMqttMessage'](
-    sl.getEntityCommandTopic((slave!.specification! as Ispecification).entities[0])!.commandTopic,
+    sl.getEntityCommandTopic((slave!.specification! as Ispecification).entities[2])!.commandTopic,
     Buffer.from(' ')
   )
     .then(() => {
@@ -488,8 +488,7 @@ class FakeMqttDeleteEntitySlave extends FakeMqtt {
 
   public override publish(topic: string, message: Buffer): void {
     if (topic.startsWith('homeassistant')) {
-      if(message.length== 0)
-        this.discoveryIsUnPublished = true
+      if (message.length == 0) this.discoveryIsUnPublished = true
     }
     this.isAsExcpected = !this.unsubscribed && this.discoveryIsUnPublished
   }
@@ -525,9 +524,7 @@ test('onAddSlave/onUpdateSlave/onDeleteSlave', (done) => {
   mdl['connectMqtt'] = function (undefined, onConnected: () => void, error: (e: any) => void) {
     onConnected()
   }
-  let spec = ConfigSpecification['specifications'].find(
-    (s: Ispecification) => s.filename == 'deyeinverterl'
-  ) as Ispecification
+  let spec = ConfigSpecification['specifications'].find((s: Ispecification) => s.filename == 'deyeinverterl') as Ispecification
   let slave: Islave = { slaveid: 7, specificationid: 'deyeinverterl', specification: spec, name: 'wl2', rootTopic: 'wl2' }
   mdl['onAddSlave'](new Slave(0, slave, Config.getConfiguration().mqttbasetopic)).then(() => {
     expect(mdl['subscribedSlaves'].length).toBe(slaveCount + 1)
@@ -558,7 +555,7 @@ test('onAddSlave/onUpdateSlave/onDeleteSlave', (done) => {
         expect(mdl['subscribedSlaves'].find((s) => s.getSlaveId() == 7)!.getSpecification()!.entities.length).toBe(2)
         fake = new FakeMqttDeleteSlaveTopic(mdl, FakeModes.Poll)
         mdl['client'] = fake as any as MqttClient
-            mdl['onDeleteSlave'](new Slave(0, slave, Config.getConfiguration().mqttbasetopic))
+        mdl['onDeleteSlave'](new Slave(0, slave, Config.getConfiguration().mqttbasetopic))
           .then(() => {
             expect(mdl['subscribedSlaves'].length).toBe(slaveCount)
             expect(fake.isAsExcpected).toBeTruthy()

--- a/__tests__/mqttdiscover_test.tsx
+++ b/__tests__/mqttdiscover_test.tsx
@@ -431,19 +431,18 @@ test('onMessage SendEntityCommandTopic from this app', (done) => {
   slave!.specification = ConfigSpecification.getSpecificationByFilename(slave!.specificationid!)
   let sl = new Slave(0, slave!, Config.getConfiguration().mqttbasetopic)
   ;(slave!.specification! as Ispecification).entities[2].readonly = false
-  let oldwriteEntityMqtt = Modbus.writeEntityMqtt 
-  let writeEntityMqttMock = jest.fn().mockImplementation( () => Promise.resolve()) 
+  let oldwriteEntityMqtt = Modbus.writeEntityMqtt
+  let writeEntityMqttMock = jest.fn().mockImplementation(() => Promise.resolve())
   Modbus.writeEntityMqtt = writeEntityMqttMock as any
   mdl['onMqttMessage'](
     sl.getEntityCommandTopic((slave!.specification! as ImodbusSpecification).entities[2])!.commandTopic!,
-    Buffer.from("20.2")
+    Buffer.from('20.2')
   )
     .then(() => {
-      
       expect(fake.isAsExcpected).toBeTruthy()
       expect(writeEntityMqttMock).toHaveBeenCalled()
       Modbus.writeEntityMqtt = oldwriteEntityMqtt
-  
+
       done()
     })
     .catch((e) => {
@@ -458,8 +457,8 @@ test('onMessage SendCommandTopic from this app', (done) => {
   copySubscribedSlaves(mdl['subscribedSlaves'], md['subscribedSlaves'])
   let fake = new FakeMqttSendCommandTopic(mdl, FakeModes.Poll)
   mdl['client'] = fake as any as MqttClient
-  let oldwriteEntityMqtt = Modbus.writeEntityMqtt 
-  let writeEntityMqttMock = jest.fn().mockImplementation( () => Promise.resolve()) 
+  let oldwriteEntityMqtt = Modbus.writeEntityMqtt
+  let writeEntityMqttMock = jest.fn().mockImplementation(() => Promise.resolve())
   Modbus.writeEntityMqtt = writeEntityMqttMock as any
 
   mdl['connectMqtt'] = function (undefined, onConnected: () => void, error: (e: any) => void) {
@@ -470,14 +469,11 @@ test('onMessage SendCommandTopic from this app', (done) => {
   slave!.specification = ConfigSpecification.getSpecificationByFilename(slave!.specificationid!)
   let sl = new Slave(0, slave!, Config.getConfiguration().mqttbasetopic)
   ;(slave!.specification! as Ispecification).entities[2].readonly = false
-  mdl['onMqttMessage'](
-    sl.getCommandTopic()!,
-    Buffer.from('{ "hotwatertargettemperature": 20.2 }')
-  )
+  mdl['onMqttMessage'](sl.getCommandTopic()!, Buffer.from('{ "hotwatertargettemperature": 20.2 }'))
     .then(() => {
       expect(writeEntityMqttMock).toHaveBeenCalled()
       Modbus.writeEntityMqtt = oldwriteEntityMqtt
-      
+
       expect(fake.isAsExcpected).toBeTruthy()
       done()
     })

--- a/__tests__/yaml-dir/local/busses/bus.0/s2.yaml
+++ b/__tests__/yaml-dir/local/busses/bus.0/s2.yaml
@@ -1,4 +1,4 @@
 specificationid: waterleveltransmitter
 slaveid: 2
-polInterval: 100
+pollInterval: 100
 evalTimeout: true

--- a/__tests__/yaml-dir/local/secrets.yaml
+++ b/__tests__/yaml-dir/local/secrets.yaml
@@ -2,4 +2,4 @@ mqttpassword: modbus2mqtt
 mqttuser: modbus2mqtt
 githubPersonalToken: someToken
 username: test
-password: $2a$08$YbumIeB5xSq/Vg0Bak6tquCXGwFhROCIEKPWQZ5to4gZ.hLLIcYSq
+password: $2a$08$ZZmhDnnM19VVpY.2PrVyzeVar5ET50INopdDucimindEh1pvw2QYC

--- a/__tests__/yaml-dir/local/specifications/files/waterleveltransmitter/files.yaml
+++ b/__tests__/yaml-dir/local/specifications/files/waterleveltransmitter/files.yaml
@@ -3,6 +3,6 @@ files:
   - url: __tests__/yaml-dir/local/specifications/files/test.pdf/specifications/files/waterleveltransmitter/test.pdf
     fileLocation: 0
     usage: doc
-  - url: specifications/files/waterleveltransmitter/test2.jpg
+  - url: specifications/files/waterleveltransmitter/test.pdf
     fileLocation: 0
     usage: doc

--- a/__tests__/yaml-dir/local/specifications/files/waterleveltransmitter/files.yaml
+++ b/__tests__/yaml-dir/local/specifications/files/waterleveltransmitter/files.yaml
@@ -3,6 +3,6 @@ files:
   - url: __tests__/yaml-dir/local/specifications/files/test.pdf/specifications/files/waterleveltransmitter/test.pdf
     fileLocation: 0
     usage: doc
-  - url: specifications/files/waterleveltransmitter/test.pdf
+  - url: specifications/files/waterleveltransmitter/test2.jpg
     fileLocation: 0
     usage: doc

--- a/__tests__/yaml-dir/local/specifications/waterleveltransmitter.yaml
+++ b/__tests__/yaml-dir/local/specifications/waterleveltransmitter.yaml
@@ -23,6 +23,26 @@ entities:
     variableConfiguration:
       targetParameter: 2
       entityId: 1
+  - id: 3
+    modbusAddress: 4
+    converter:
+      name: number
+      registerTypes:
+        - 3
+        - 4
+    converterParameters:
+      multiplier: 1
+      offset: 0
+      numberFormat: 0
+      identification:
+        min: 31
+        max: 70
+      uom: °C
+    mqttname: hotwatertargettemperature
+    valid: true
+    registerType: 3
+    readonly: false
+    modbusError: ""
 i18n:
   - lang: en
     texts:
@@ -30,5 +50,7 @@ i18n:
         text: Water Level Transmitter
       - textId: e1
         text: Water Level Transmitter
+      - textId: e3
+        text: Hot Water Target Temperature
 version: "0.3"
 testdata: {}

--- a/cypress/e2e/discovery.cy.js
+++ b/cypress/e2e/discovery.cy.js
@@ -155,7 +155,7 @@ describe('MQTT Discovery Tests', () => {
       let willLog = true
       let logSetting = { log: willLog }
       cy.exec('npm run e2e:reset', logSetting)
-      prefix = 'modbus2mqtt'
+      prefix = 'ingress'
       cy.visit('http://localhost:80/' + prefix, logSetting)
       // monitor discovery topics
       let mqttConnect = Cypress.env('mqttconnect')

--- a/cypress/e2e/discovery.cy.js
+++ b/cypress/e2e/discovery.cy.js
@@ -26,7 +26,8 @@ function runSlaves(willLog) {
   cy.get('[formcontrolname="slaveId"]', logSetting).type('3{enter}', { force: true, log: willLog })
   // Show specification third header button on first card
 
-  cy.get('div.card-header-buttons:first button', logSetting).eq(2, logSetting).click(logSetting)
+  cy.get('div.card-header-buttons:first button ', logSetting).eq(1, logSetting).click(logSetting)
+  cy.get('div.card-header-buttons:first button ', logSetting).eq(2, logSetting).click(logSetting)
   cy.url().should('contain', prefix + '/specification')
 }
 function setUrls(willLog) {
@@ -119,7 +120,8 @@ function addSlave(willLog) {
     .get('mat-option')
     .contains('No polling')
     .click(logSetting)
-  // Show specification third header button on first card
+  cy.get('div.card-header-buttons:first button:contains("check_circle")', logSetting).eq(0, logSetting).click(logSetting)
+    // Show specification third header button on first card
   cy.get('div.card-header-buttons:first button:contains("add_box")', logSetting).eq(0, logSetting).click(logSetting)
 
   cy.url().should('contain', prefix + '/specification')
@@ -177,14 +179,19 @@ describe('MQTT Discovery Tests', () => {
           addEntity(2, 3, false)
           saveSpecification(false)
           //Homeassistant need time between discovery and state sending
-          cy.wait(500)
+          cy.wait(1000)
             .task('mqttGetTopicAndPayloads')
             .then((tAndP) => {
               //expect(tAndP.length).to.eq(2)
-              expect(tAndP.findIndex((tp) => tp.payload == 'online')).not.to.eq(-1)
-              expect(tAndP.findIndex((tp) => tp.topic.endsWith('/state/'))).not.to.eq(-1)
+              let idx = tAndP.findIndex((tp) => tp.payload == 'online')
+              if( idx == -1 )
+                console.log( tAndP )
+              expect(idx).not.to.eq(-1)
+              idx = tAndP.findIndex((tp) => tp.topic.endsWith('/state/'))
+              if( idx == -1 )
+                console.log( tAndP )
+              expect(idx ).not.to.eq(-1)
               expect(tAndP.filter((tp) => tp.topic.startsWith('homeassistant/')).length).to.eq(2)
-              cy.log('tAndP ' + JSON.stringify(tAndP, null, 4))
             })
           cy.readFile('e2e/temp/yaml-dir-addon/local/specifications/files/thespec/files.yaml').should('exist')
         })

--- a/cypress/e2e/discovery.cy.js
+++ b/cypress/e2e/discovery.cy.js
@@ -121,7 +121,7 @@ function addSlave(willLog) {
     .contains('No polling')
     .click(logSetting)
   cy.get('div.card-header-buttons:first button:contains("check_circle")', logSetting).eq(0, logSetting).click(logSetting)
-    // Show specification third header button on first card
+  // Show specification third header button on first card
   cy.get('div.card-header-buttons:first button:contains("add_box")', logSetting).eq(0, logSetting).click(logSetting)
 
   cy.url().should('contain', prefix + '/specification')
@@ -184,13 +184,11 @@ describe('MQTT Discovery Tests', () => {
             .then((tAndP) => {
               //expect(tAndP.length).to.eq(2)
               let idx = tAndP.findIndex((tp) => tp.payload == 'online')
-              if( idx == -1 )
-                console.log( tAndP )
+              if (idx == -1) console.log(tAndP)
               expect(idx).not.to.eq(-1)
               idx = tAndP.findIndex((tp) => tp.topic.endsWith('/state/'))
-              if( idx == -1 )
-                console.log( tAndP )
-              expect(idx ).not.to.eq(-1)
+              if (idx == -1) console.log(tAndP)
+              expect(idx).not.to.eq(-1)
               expect(tAndP.filter((tp) => tp.topic.startsWith('homeassistant/')).length).to.eq(2)
             })
           cy.readFile('e2e/temp/yaml-dir-addon/local/specifications/files/thespec/files.yaml').should('exist')

--- a/cypress/e2e/discovery.cy.js
+++ b/cypress/e2e/discovery.cy.js
@@ -5,110 +5,141 @@ let mqttUnAuthorizedPort = 3003
 
 function runBusses(willLog) {
   let logSetting = { log: willLog }
-  cy.log("Configure Bus")
+  cy.log('Configure Bus')
   cy.url().should('contain', prefix + '/busses')
-  cy.get('[role="tab"] ',logSetting).eq(1,logSetting).click(logSetting)
-  cy.get('[formcontrolname="host"]',logSetting).type(backspaces(10) + 'localhost', { force: true, log:willLog })
-  cy.get('[formcontrolname="port"]',logSetting).type(backspaces(10) +'3002', { force: true, log:willLog })
-  cy.get('[formcontrolname="timeout"]',logSetting).eq(0, logSetting).type(backspaces(10) +'500', { force: true, log:willLog })
-  cy.get('[formcontrolname="host"]',logSetting).trigger('change', logSetting)
-  cy.get('div.card-header-buttons button:first',logSetting).eq(0).click(logSetting)
+  cy.get('[role="tab"] ', logSetting).eq(1, logSetting).click(logSetting)
+  cy.get('[formcontrolname="host"]', logSetting).type(backspaces(10) + 'localhost', { force: true, log: willLog })
+  cy.get('[formcontrolname="port"]', logSetting).type(backspaces(10) + '3002', { force: true, log: willLog })
+  cy.get('[formcontrolname="timeout"]', logSetting)
+    .eq(0, logSetting)
+    .type(backspaces(10) + '500', { force: true, log: willLog })
+  cy.get('[formcontrolname="host"]', logSetting).trigger('change', logSetting)
+  cy.get('div.card-header-buttons button:first', logSetting).eq(0).click(logSetting)
   // List slaves second header button on first card
   cy.get('div.card-header-buttons:first button').eq(1, logSetting).click(logSetting)
 }
 
 function runSlaves(willLog) {
   let logSetting = { log: willLog }
-  cy.log("Create Slave")
+  cy.log('Create Slave')
   cy.url().should('contain', prefix + '/slaves')
-  cy.get('[formcontrolname="slaveId"]',logSetting).type('3{enter}', { force: true, log:willLog })
+  cy.get('[formcontrolname="slaveId"]', logSetting).type('3{enter}', { force: true, log: willLog })
   // Show specification third header button on first card
 
-  cy.get('div.card-header-buttons:first button',logSetting).eq(2,logSetting).click(logSetting)
+  cy.get('div.card-header-buttons:first button', logSetting).eq(2, logSetting).click(logSetting)
   cy.url().should('contain', prefix + '/specification')
 }
-function setUrls(willLog){
+function setUrls(willLog) {
   let logSetting = { log: willLog }
-  cy.log("Set Upload files URLs")
-  cy.get('app-upload-files:first mat-expansion-panel-header',logSetting).eq(1,logSetting).click(logSetting)
-  cy.get('app-upload-files:first input[type!="file"]',logSetting).eq(1,logSetting).focus(logSetting).type('http://localhost/test.png', { force: true, log:willLog })
-  cy.get('app-upload-files:first button mat-icon:contains("add")',logSetting).eq(1,logSetting).click({ force: true, log:willLog })
-  
-  cy.get('app-upload-files:first mat-expansion-panel-header',logSetting).eq(0,logSetting).click(logSetting)
-  cy.get('app-upload-files:first input[type!="file"]',logSetting).eq(0,logSetting).focus(logSetting).type('http://localhost/test.pdf', { force: true, log:willLog })
-  cy.get('app-upload-files:first button mat-icon:contains("add")',logSetting).eq(0,logSetting).click({ force: true, log:willLog  }).wait(1000)
+  cy.log('Set Upload files URLs')
+  cy.get('app-upload-files:first mat-expansion-panel-header', logSetting).eq(1, logSetting).click(logSetting)
+  cy.get('app-upload-files:first input[type!="file"]', logSetting)
+    .eq(1, logSetting)
+    .focus(logSetting)
+    .type('http://localhost/test.png', { force: true, log: willLog })
+  cy.get('app-upload-files:first button mat-icon:contains("add")', logSetting)
+    .eq(1, logSetting)
+    .click({ force: true, log: willLog })
 
+  cy.get('app-upload-files:first mat-expansion-panel-header', logSetting).eq(0, logSetting).click(logSetting)
+  cy.get('app-upload-files:first input[type!="file"]', logSetting)
+    .eq(0, logSetting)
+    .focus(logSetting)
+    .type('http://localhost/test.pdf', { force: true, log: willLog })
+  cy.get('app-upload-files:first button mat-icon:contains("add")', logSetting)
+    .eq(0, logSetting)
+    .click({ force: true, log: willLog })
+    .wait(1000)
 }
-function addEntity(entitynum, modbusAddress, willLog){
+function addEntity(entitynum, modbusAddress, willLog) {
   let logSetting = { log: willLog }
-  cy.log("Add entity " + entitynum)
-  cy.get('app-entity:last mat-expansion-panel-header[aria-expanded=false]',logSetting).then((elements=>{
-    if( elements.length >=1 ){
+  cy.log('Add entity ' + entitynum)
+  cy.get('app-entity:last mat-expansion-panel-header[aria-expanded=false]', logSetting).then((elements) => {
+    if (elements.length >= 1) {
       elements[0].click(logSetting)
     }
-    if( elements.length >=2 ){
+    if (elements.length >= 2) {
       elements[1].click(logSetting)
     }
-  }))
+  })
 
-//  cy.get('app-entity:last mat-expansion-panel-header',logSetting).eq(0,logSetting).click(logSetting)
-  cy.get('app-entity:last [formcontrolname="name"]',logSetting).type('the entity'+ entitynum + '{enter}', { force: true, log:willLog })
-  cy.get('app-entity:last [formcontrolname="modbusAddress"]',logSetting).type('{backspace}' + modbusAddress+ '{enter}', { force: true, log:willLog })
-  cy.get('app-entity:last mat-select[formControlName="converter"]',logSetting).click(logSetting).get('mat-option').contains('number').click(logSetting);
-  cy.get('app-entity:last [formControlName="readonly"]',logSetting).click(logSetting)
-  
-  cy.get('app-entity:last [formcontrolname="min"]',logSetting).type('0', { force: true, log:willLog })
-  cy.get('app-entity:last [formcontrolname="max"]',logSetting).type('1000', { force: true, log:willLog })
-  cy.get('app-entity:last mat-select[formControlName="registerType"]',logSetting).click().get('mat-option').contains('Holding').click(logSetting);
-  cy.get('app-entity:last mat-card mat-card-header button:has(mat-icon:contains("add_circle"))',logSetting).last().click({ force: true, log:willLog })
+  //  cy.get('app-entity:last mat-expansion-panel-header',logSetting).eq(0,logSetting).click(logSetting)
+  cy.get('app-entity:last [formcontrolname="name"]', logSetting).type('the entity' + entitynum + '{enter}', {
+    force: true,
+    log: willLog,
+  })
+  cy.get('app-entity:last [formcontrolname="modbusAddress"]', logSetting).type('{backspace}' + modbusAddress + '{enter}', {
+    force: true,
+    log: willLog,
+  })
+  cy.get('app-entity:last mat-select[formControlName="converter"]', logSetting)
+    .click(logSetting)
+    .get('mat-option')
+    .contains('number')
+    .click(logSetting)
+  cy.get('app-entity:last [formControlName="readonly"]', logSetting).click(logSetting)
+
+  cy.get('app-entity:last [formcontrolname="min"]', logSetting).type('0', { force: true, log: willLog })
+  cy.get('app-entity:last [formcontrolname="max"]', logSetting).type('1000', { force: true, log: willLog })
+  cy.get('app-entity:last mat-select[formControlName="registerType"]', logSetting)
+    .click()
+    .get('mat-option')
+    .contains('Holding')
+    .click(logSetting)
+  cy.get('app-entity:last mat-card mat-card-header button:has(mat-icon:contains("add_circle"))', logSetting)
+    .last()
+    .click({ force: true, log: willLog })
 }
-function saveSpecification(willLog){
+function saveSpecification(willLog) {
   let logSetting = { log: willLog }
-  cy.log("Save Specification ")
-    cy.get('div.saveCancel:first button', logSetting).eq(0, logSetting).should("not.is.disabled")
-    cy.get('div.saveCancel:first button',logSetting).eq(0,logSetting).trigger("click",logSetting)
-    cy.get('div.saveCancel:first button', logSetting).eq(0, logSetting).should("is.disabled")
-    cy.get('div.saveCancel:first button', logSetting).eq(1, logSetting).trigger("click",logSetting)  
-    cy.url().should('contain', prefix + '/slaves')
-  }
+  cy.log('Save Specification ')
+  cy.get('div.saveCancel:first button', logSetting).eq(0, logSetting).should('not.is.disabled')
+  cy.get('div.saveCancel:first button', logSetting).eq(0, logSetting).trigger('click', logSetting)
+  cy.get('div.saveCancel:first button', logSetting).eq(0, logSetting).should('is.disabled')
+  cy.get('div.saveCancel:first button', logSetting).eq(1, logSetting).trigger('click', logSetting)
+  cy.url().should('contain', prefix + '/slaves')
+}
 function addSlave(willLog) {
   let logSetting = { log: willLog }
-  cy.log("Add Slave ")
+  cy.log('Add Slave ')
   cy.url().should('contain', prefix + '/slaves')
-  cy.get('[formcontrolname="detectSpec"]', logSetting).click( logSetting)
-  cy.get('[formcontrolname="slaveId"]', logSetting).type('10{enter}', { force: true, log:willLog })
-  cy.get('app-select-slave:first mat-expansion-panel-header[aria-expanded=false]',logSetting).then((elements=>{
-    if( elements.length >=1 ){
+  cy.get('[formcontrolname="detectSpec"]', logSetting).click(logSetting)
+  cy.get('[formcontrolname="slaveId"]', logSetting).type('10{enter}', { force: true, log: willLog })
+  cy.get('app-select-slave:first mat-expansion-panel-header[aria-expanded=false]', logSetting).then((elements) => {
+    if (elements.length >= 1) {
       elements[0].click(logSetting)
     }
-    if( elements.length >=2 ){
+    if (elements.length >= 2) {
       elements[1].click(logSetting)
     }
-  }))    
+  })
 
-  cy.get('app-select-slave:first mat-select[formControlName="pollMode"]',logSetting).click().get('mat-option').contains('No polling').click(logSetting)
+  cy.get('app-select-slave:first mat-select[formControlName="pollMode"]', logSetting)
+    .click()
+    .get('mat-option')
+    .contains('No polling')
+    .click(logSetting)
   // Show specification third header button on first card
-  cy.get('div.card-header-buttons:first button:contains("add_box")', logSetting).eq(0, logSetting).click( logSetting)
+  cy.get('div.card-header-buttons:first button:contains("add_box")', logSetting).eq(0, logSetting).click(logSetting)
 
   cy.url().should('contain', prefix + '/specification')
 }
-function validateMqtt(willLog){
+function validateMqtt(willLog) {
   let logSetting = { log: willLog }
-  return new Promise((resolve)=>{
-    cy.log("Validate MQTT")
-    cy.task('mqttResetTopicAndPayloads', logSetting).then(()=>{
+  return new Promise((resolve) => {
+    cy.log('Validate MQTT')
+    cy.task('mqttResetTopicAndPayloads', logSetting).then(() => {
       cy.task('mqttGetTopicAndPayloads', logSetting).then((tAndP) => {
         cy.log('tAndP ' + JSON.stringify(tAndP))
-      })})
+      })
+    })
   })
 }
-function backspaces(num){
-  let rc = ""
-  for(let a=0; a < num; a++)
-    rc = rc + "{backspace}"
+function backspaces(num) {
+  let rc = ''
+  for (let a = 0; a < num; a++) rc = rc + '{backspace}'
   return rc
-} 
-
+}
 
 describe('MQTT Discovery Tests', () => {
   it(
@@ -120,8 +151,8 @@ describe('MQTT Discovery Tests', () => {
       },
     },
     () => {
-      Cypress.config('defaultCommandTimeout', 20000 )
-      let willLog= true
+      Cypress.config('defaultCommandTimeout', 20000)
+      let willLog = true
       let logSetting = { log: willLog }
       cy.exec('npm run e2e:reset', logSetting)
       prefix = 'modbus2mqtt'
@@ -129,30 +160,35 @@ describe('MQTT Discovery Tests', () => {
       // monitor discovery topics
       let mqttConnect = Cypress.env('mqttconnect')
       assert(mqttConnect != undefined)
-      cy.log("MQTT connect")
+      cy.log('MQTT connect')
       cy.task('mqttConnect', mqttConnect, logSetting).then(() => {
         cy.task('mqttSubscribe', '#', logSetting).then((tAndP) => {
-          cy.task("mqttResetTopicAndPayloads")
+          cy.task('mqttResetTopicAndPayloads')
           runBusses(true)
           addSlave(true)
-          cy.log("Configure Specification name")
-          cy.get('#specForm [formcontrolname="name"]', {log:false}).type(backspaces(10) + 'the spec{enter}', { force: true, log: willLog })
+          cy.log('Configure Specification name')
+          cy.get('#specForm [formcontrolname="name"]', { log: false }).type(backspaces(10) + 'the spec{enter}', {
+            force: true,
+            log: willLog,
+          })
 
           setUrls(true)
-          addEntity(1,1,false )
-          addEntity(2,3,false )
+          addEntity(1, 1, false)
+          addEntity(2, 3, false)
           saveSpecification(false)
           //Homeassistant need time between discovery and state sending
-          cy.wait(500).task('mqttGetTopicAndPayloads').then((tAndP) => {
-            //expect(tAndP.length).to.eq(2)
-            expect( tAndP.findIndex(tp=>tp.payload == "online")).not.to.eq(-1)
-            expect( tAndP.findIndex(tp=>tp.topic.endsWith("/state/"))).not.to.eq(-1)
-            expect( tAndP.filter(tp=>tp.topic.startsWith("homeassistant/")).length).to.eq(2)
-            cy.log('tAndP ' + JSON.stringify(tAndP, null, 4))
-          })
-          cy.readFile('e2e/temp/yaml-dir-addon/local/specifications/files/thespec/files.yaml').should("exist")
-        
-    })
-    })
-})
+          cy.wait(500)
+            .task('mqttGetTopicAndPayloads')
+            .then((tAndP) => {
+              //expect(tAndP.length).to.eq(2)
+              expect(tAndP.findIndex((tp) => tp.payload == 'online')).not.to.eq(-1)
+              expect(tAndP.findIndex((tp) => tp.topic.endsWith('/state/'))).not.to.eq(-1)
+              expect(tAndP.filter((tp) => tp.topic.startsWith('homeassistant/')).length).to.eq(2)
+              cy.log('tAndP ' + JSON.stringify(tAndP, null, 4))
+            })
+          cy.readFile('e2e/temp/yaml-dir-addon/local/specifications/files/thespec/files.yaml').should('exist')
+        })
+      })
+    }
+  )
 })

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -42,7 +42,7 @@ function runSlaves(willLog) {
   cy.url().should('contain', prefix + '/slaves')
   cy.get('[formcontrolname="slaveId"]').type('3{enter}', { force: true })
   // Show specification third header button on first card
-  cy.get('div.card-header-buttons:first button:contains("add_box")', logSetting).eq(0, logSetting).click( logSetting)
+  cy.get('div.card-header-buttons:first button:contains("add_box")', logSetting).eq(0, logSetting).click(logSetting)
   cy.url().should('contain', prefix + '/specification')
 }
 

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -87,7 +87,7 @@ describe('End to End Tests', () => {
     },
     () => {
       cy.exec('npm run e2e:reset')
-      prefix = 'modbus2mqtt'
+      prefix = 'ingress'
       cy.visit('http://localhost:80/' + prefix)
       runBusses()
     }

--- a/cypress/functions/mqtt.js
+++ b/cypress/functions/mqtt.js
@@ -19,9 +19,8 @@ class MqttHelper {
   }
 
   onMessage(topic, payload, packet) {
-    if (this.tAndP && ! this.tAndP.find(tp=>tp.messageId == packet.messageId )) 
-    {
-      console.log('onMessage id:' + packet.messageId + " topic:" + topic + " payload: " + payload.toString())
+    if (this.tAndP && !this.tAndP.find((tp) => tp.messageId == packet.messageId)) {
+      console.log('onMessage id:' + packet.messageId + ' topic:' + topic + ' payload: ' + payload.toString())
       this.tAndP.push({ topic: topic, payload: payload.toString(), messageId: packet.messageId })
     }
   }

--- a/cypress/functions/mqtt.js
+++ b/cypress/functions/mqtt.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true })
 const mqtt = require('mqtt')
 let instance = undefined
+
 exports.MqttHelper = void 0
 function getInstance() {
   if (instance == undefined) {
@@ -14,6 +15,7 @@ function getInstance() {
 class MqttHelper {
   client
   tAndP
+  connectionData
   constructor() {
     this.tAndP = []
   }
@@ -26,24 +28,46 @@ class MqttHelper {
   }
 
   connect(connectionData) {
+    this.connectionData = structuredClone(connectionData)
+    this.connectionData.clean = false
+    this.connectionData.reconnectPeriod = 5000
+    this.connectionData.clientId = 'm2mCypress'
+
     return new Promise((resolve, reject) => {
-      this.client = mqtt.connect(connectionData.mqttserverurl, connectionData)
+      if (this.client)
+        if (this.client.connected) {
+          resolve(this.client)
+          return
+        } else this.client.reconnect(this.connectionData)
+      else this.client = mqtt.connect(connectionData.mqttserverurl, this.connectionData)
       this.client.on('error', reject)
       this.client.on('message', this.onMessage.bind(this))
       this.client.on('connect', () => {
-        resolve()
+        resolve(this.client)
       })
     })
   }
   publish(topic, payload) {
-    this.client.publish(topic, payload, { qos: 1 })
+    this.connect(this.connectionData).then((mqttClient) => {
+      mqttClient.publish(topic, payload, { qos: 1 })
+    })
   }
   subscribe(topic) {
-    this.client.subscribe(topic, { qos: 1 })
+    this.connect(this.connectionData)
+      .then((mqttClient) => {
+        this.client.subscribe(topic, { qos: 1 })
+      })
+      .catch((e) => {
+        console.log('Unable to subscribe ' + e.message)
+      })
   }
   getTopicAndPayloads() {
-    return new Promise((resolve) => {
-      resolve(this.tAndP)
+    return new Promise((resolve, reject) => {
+      this.connect(this.connectionData)
+        .then(() => {
+          resolve(this.tAndP)
+        })
+        .catch(reject)
     })
   }
   resetTopicAndPayloads() {

--- a/e2e/localdev.sh
+++ b/e2e/localdev.sh
@@ -81,8 +81,11 @@ rm -rf ${BASEDIR}/temp/yaml-dir ${BASEDIR}/temp/yaml-dir-addon
 mkdir -p ${BASEDIR}/temp/yaml-dir/local
 mkdir -p ${BASEDIR}/temp/log
 echo 'httpport: 3005' >${BASEDIR}/temp/yaml-dir/local/modbus2mqtt.yaml
+chmod 777 ${BASEDIR}/temp/yaml-dir/local/modbus2mqtt.yaml
 mkdir -p ${BASEDIR}/temp/yaml-dir-addon/local
 (echo "httpport: 3004" &&  echo "supervisor_host: localhost" )>${BASEDIR}/temp/yaml-dir-addon/local/modbus2mqtt.yaml
+chmod 777 ${BASEDIR}/temp/yaml-dir-addon/local/modbus2mqtt.yaml
+
 # reset: init yaml-dir and restart modbus2mqtt services
 if [ "$1" == "reset" ]
 then

--- a/e2e/localdev.sh
+++ b/e2e/localdev.sh
@@ -256,8 +256,8 @@ StartLimitIntervalSec=1
 [Service]
 Type=simple
 Environment="HASSIO_TOKEN=abcd1234"
-Environment="DEBUG=config.addon"
-ExecStart=|node| |cwd|/dist/modbus2mqtt.js -y |cwd|/e2e/temp/yaml-dir-addon -s |cwd|/e2e/temp/ssl 
+Environment="DEBUG=config.addon mqttclient"
+ExecStart=|node|  |cwd|/dist/modbus2mqtt.js -y |cwd|/e2e/temp/yaml-dir-addon -s |cwd|/e2e/temp/ssl 
 [Install]
 WantedBy=multi-user.target
 EOF10'  | sed -e "s:|cwd|:${SERVERDIR}:g" | sed -e "s:|node|:"`which node`":g" | bash -c 'cat >'$SERVICES'/modbus2mqtt-addon.service'

--- a/e2e/localdev.sh
+++ b/e2e/localdev.sh
@@ -133,10 +133,10 @@ sudo bash -c 'cat >'$WWWROOT'/addons/self/info/info.json <<EOF
   "data":{
     "slug": "slugtest",
     "ingress": true,
-    "ingress_entry": "modbus2mqtt",
+    "ingress_entry": "ingress",
     "ingress_panel" : true,
     "ingress_port": 1234,
-    "ingress_url": "modbus2mqtt"
+    "ingress_url": "ingress"
   }
 }
 EOF'
@@ -171,7 +171,7 @@ server {
      index hardware.json;
   }
 
-  location /modbus2mqtt/ {
+  location /ingress/ {
         proxy_pass http://localhost:3004/;
         proxy_pass_header Content-Type; 
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@modbus2mqtt/server",
-  "version": "0.16.16",
+  "version": "0.16.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modbus2mqtt/server",
-      "version": "0.16.16",
+      "version": "0.16.17",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/translate": "^8.3.0",
-        "@modbus2mqtt/angular": "^0.12.13",
-        "@modbus2mqtt/server.shared": "^0.13.9",
-        "@modbus2mqtt/specification": "^0.15.24",
+        "@modbus2mqtt/angular": "^0.12.14",
+        "@modbus2mqtt/server.shared": "^0.13.10",
+        "@modbus2mqtt/specification": "^0.15.25",
         "@modbus2mqtt/specification.shared": "^0.10.8",
         "@octokit/rest": "^20.1.1",
         "adm-zip": "^0.5.16",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.0.4.tgz",
-      "integrity": "sha512-iGuOMlVhLBmGCSJ5azqwLdsBIFlWXtB+CffeoJjKXGjR2YRxP1aylNccB5UqE7G/XjNNLjJfLkm+nQUAWGLMNg==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.0.5.tgz",
+      "integrity": "sha512-HCOF2CrhUvjoZWusd4nh32VOxpUrg6bV+3Z8Q36Ix3aZdni8v0qoP2rl5wGbotaPtYg5RtyDH60Z2AOPKqlrZg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -112,13 +112,13 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.0.4"
+        "@angular/core": "19.0.5"
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.0.3.tgz",
-      "integrity": "sha512-sPdIKbSgNk4z02FqdTTMUS62aLVA2R/DsnOk3qdH+nEfeS4nNWQEzwrvMf6dDsTeLQ6YJLWXfZfemsGYpOoiWg==",
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.0.4.tgz",
+      "integrity": "sha512-P8V1n6AFFjBUJG3YRgw8DiiNDWPZVrwQ42wbwgZxd4s2TQAuNFg3YY8h/DSMVxt2sXpavrshZsoLtP9yLKZjHA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.0.4.tgz",
-      "integrity": "sha512-SBWraO5NVZa/QJPrVbk3IsUmZQDriYBvqYuZFJaI/UTbhcAedNRsLDbKHtOYrHHx6K1saPXSQCufWgFo30lEqw==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.0.5.tgz",
+      "integrity": "sha512-fFK+euCj1AjBHBCpj9VnduMSeqoMRhZZHbhPYiND7tucRRJ8vwGU0sYK2KI/Ko+fsrNIXL/0O4F36jVPl09Smg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -146,14 +146,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.0.4",
+        "@angular/core": "19.0.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/core": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.0.4.tgz",
-      "integrity": "sha512-eoLixL8+03HpMIrmbL9lX+PAEw/fJSGshUH99IN9ZgCDEWeAlORg3U5RQEEh59ovelGfTn/sNaYhWsLVoBUIYQ==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.0.5.tgz",
+      "integrity": "sha512-Ywc6sPO6G/Y1stfk3y/MallV/h0yzQ0vdOHRWueLrk5kD1DTdbolV4X03Cs3PuVvravgcSVE3nnuuHFuH32emQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -168,9 +168,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.0.4.tgz",
-      "integrity": "sha512-smBCOjqCOMjHxRwwmImo58esSatGRsIxEaPytMezWWXqcD9pCZFzHskXA7218cJBRO8T9wuAf5AJFSqD4Yg72A==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.0.5.tgz",
+      "integrity": "sha512-OhNFkfOoguqCDq07vNBV28FFrmTM8S11Z3Cd6PQZJJF9TgAtpV5KtF7A3eXBCN92W4pmqluomPjfK7YyImzIYQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -180,16 +180,16 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.0.4",
-        "@angular/core": "19.0.4",
-        "@angular/platform-browser": "19.0.4",
+        "@angular/common": "19.0.5",
+        "@angular/core": "19.0.5",
+        "@angular/platform-browser": "19.0.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/material": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-19.0.3.tgz",
-      "integrity": "sha512-aHAnmEzoE6nEF7S/lBlMwDMs6ZEkvE3omg9g6jY6WyKWtP9HYeCfwxmTPVclqcbXWxJWO/5Bvwfcjzs75uC+YA==",
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-19.0.4.tgz",
+      "integrity": "sha512-8WRMbN1+oRXx1ZFLni+BRz60F4FWzJPFORsQ8qAvY3sHWzyjunsYZkpbze3uiZO6bu3hiyQCU6g+k/58Qc6kkw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -197,7 +197,7 @@
       },
       "peerDependencies": {
         "@angular/animations": "^19.0.0 || ^20.0.0",
-        "@angular/cdk": "19.0.3",
+        "@angular/cdk": "19.0.4",
         "@angular/common": "^19.0.0 || ^20.0.0",
         "@angular/core": "^19.0.0 || ^20.0.0",
         "@angular/forms": "^19.0.0 || ^20.0.0",
@@ -206,9 +206,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.0.4.tgz",
-      "integrity": "sha512-/PRr7kLVVqNFqAkw+SK8RwqE479qCcUyuw6GOHtGabt3ZfQKSbx+pTioVrZFEy5pTBMslCPV5q3I+wGRG7/nyg==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.0.5.tgz",
+      "integrity": "sha512-41+Jo5DEil4Ifvv+UE/p1l9YJtYN+xfhx+/C9cahVgvV5D2q+givyK73d0Mnb6XOfe1q+hoV5lZ+XhQYp21//g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -218,9 +218,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "19.0.4",
-        "@angular/common": "19.0.4",
-        "@angular/core": "19.0.4"
+        "@angular/animations": "19.0.5",
+        "@angular/common": "19.0.5",
+        "@angular/core": "19.0.5"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -2482,17 +2482,17 @@
       }
     },
     "node_modules/@modbus2mqtt/angular": {
-      "version": "0.12.13",
-      "resolved": "https://registry.npmjs.org/@modbus2mqtt/angular/-/angular-0.12.13.tgz",
-      "integrity": "sha512-i+J1PeNnQfZP2IghqW+PCxaE9blrRccKzTFVvMjCkAAyH4rP3He02RCFpxjC5HMOyIQDdu3jqJBZlcs/5G5IFQ==",
+      "version": "0.12.14",
+      "resolved": "https://registry.npmjs.org/@modbus2mqtt/angular/-/angular-0.12.14.tgz",
+      "integrity": "sha512-LBGCOWI1g8svjlvRSb95Zlw7Czxcu3L7sarnGMaWTFQMlRVLi0qGk5ffie4yIjQv6lXe0AjgVJjKBfORDTbVVQ==",
       "dependencies": {
         "mat-icon-button-sizes": "^1.0.6"
       }
     },
     "node_modules/@modbus2mqtt/server.shared": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/@modbus2mqtt/server.shared/-/server.shared-0.13.9.tgz",
-      "integrity": "sha512-Otn2z+8zoru47qdg6Cf5BvyQ5Li2myPy/3rl4o23+2PEETi01ZpMM2ItJ1KL1qAAs8JOg6aGXiaIhHacKH7vCA==",
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/@modbus2mqtt/server.shared/-/server.shared-0.13.10.tgz",
+      "integrity": "sha512-FEXp3z1raruqq81vwAO2YvuKIXTg7Lnb+YKEHL1PtO09t5ykXpI82m4XSiH3ZeZ6oEERj72kphcu0QWBnPLvlA==",
       "license": "MIT",
       "dependencies": {
         "@modbus2mqtt/specification.shared": "^0.10.8",
@@ -2500,9 +2500,9 @@
       }
     },
     "node_modules/@modbus2mqtt/specification": {
-      "version": "0.15.24",
-      "resolved": "https://registry.npmjs.org/@modbus2mqtt/specification/-/specification-0.15.24.tgz",
-      "integrity": "sha512-jn5frMc0Cn0wkdOUz0IjwVxulI9JxGxVSdQ9r4c2kMI99pjWDW9K+YqaQJe0hR8YPQCFAUrmvRH/SkbtN/TCFA==",
+      "version": "0.15.25",
+      "resolved": "https://registry.npmjs.org/@modbus2mqtt/specification/-/specification-0.15.25.tgz",
+      "integrity": "sha512-fC9huA+qnczlel5Eu64Squ8xDTX6o2tArszvX+HrNifrsGFQM8cKp3OGBPhvicEWEuJJIDszneotork4TMQiAA==",
       "license": "MIT",
       "dependencies": {
         "@modbus2mqtt/specification.shared": "^0.10.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modbus2mqtt/server",
-  "version": "0.16.16",
+  "version": "0.16.17",
   "sshserver": "homeassistant@homeassistant.lan",
   "homepage": "https://github.com/modbus2mqtt/server/README.md",
   "description": "server for modbus2mqtt for REST API of configuration and publishing modbus values to mqtt",
@@ -37,9 +37,9 @@
   },
   "dependencies": {
     "@google-cloud/translate": "^8.3.0",
-    "@modbus2mqtt/angular": "^0.12.13",
-    "@modbus2mqtt/server.shared": "^0.13.9",
-    "@modbus2mqtt/specification": "^0.15.24",
+    "@modbus2mqtt/angular": "^0.12.14",
+    "@modbus2mqtt/server.shared": "^0.13.10",
+    "@modbus2mqtt/specification": "^0.15.25",
     "@modbus2mqtt/specification.shared": "^0.10.8",
     "@octokit/rest": "^20.1.1",
     "adm-zip": "^0.5.16",

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -62,7 +62,7 @@ export class Bus {
     }
   }
   static getBusses(): Bus[] {
-    if (!Bus.busses|| Bus.busses.length != ConfigBus.getBussesProperties().length) {
+    if (!Bus.busses || Bus.busses.length != ConfigBus.getBussesProperties().length) {
       Bus.readBussesFromConfig()
     }
     //debug("getBusses Number of busses:" + Bus.busses!.length)

--- a/src/config.ts
+++ b/src/config.ts
@@ -228,7 +228,7 @@ export class Config {
         : DEFAULT_MQTT_CONNECT_TIMEOUT
       Config.config.mqttconnect.clientId = Config.config.mqttconnect.clientId ? Config.config.mqttconnect.clientId : 'modbus2mqtt'
       Config.config.mqttconnect.clean = Config.config.mqttconnect.clean ? Config.config.mqttconnect.clean : true
-      delete Config.config.mqttconnect.will 
+      delete Config.config.mqttconnect.will
       Config.config.httpport = Config.config.httpport ? Config.config.httpport : 3000
       Config.config.fakeModbus = Config.config.fakeModbus ? Config.config.fakeModbus : false
       Config.config.noAuthentication = Config.config.noAuthentication ? Config.config.noAuthentication : false

--- a/src/config.ts
+++ b/src/config.ts
@@ -228,6 +228,7 @@ export class Config {
         : DEFAULT_MQTT_CONNECT_TIMEOUT
       Config.config.mqttconnect.clientId = Config.config.mqttconnect.clientId ? Config.config.mqttconnect.clientId : 'modbus2mqtt'
       Config.config.mqttconnect.clean = Config.config.mqttconnect.clean ? Config.config.mqttconnect.clean : true
+      delete Config.config.mqttconnect.will 
       Config.config.httpport = Config.config.httpport ? Config.config.httpport : 3000
       Config.config.fakeModbus = Config.config.fakeModbus ? Config.config.fakeModbus : false
       Config.config.noAuthentication = Config.config.noAuthentication ? Config.config.noAuthentication : false

--- a/src/configbus.ts
+++ b/src/configbus.ts
@@ -22,9 +22,14 @@ export class ConfigBus {
   private static emitSlaveEvent(event: ConfigListenerEvent, arg: Slave) {
     let rc = MqttDiscover.addSpecificationToSlave(arg)
     ConfigBus.listeners.forEach((eventListener) => {
-      if (eventListener.event == event) (eventListener.listener as (arg: Slave) => Promise<void>)(rc).then(()=>{
-        debug("Event listener executed")
-      }).catch(e=>{ log.log(LogLevelEnum.error, "Unable to call event listener: " + e.message)})
+      if (eventListener.event == event)
+        (eventListener.listener as (arg: Slave) => Promise<void>)(rc)
+          .then(() => {
+            debug('Event listener executed')
+          })
+          .catch((e) => {
+            log.log(LogLevelEnum.error, 'Unable to call event listener: ' + e.message)
+          })
     })
   }
   private static emitBusEvent(event: ConfigListenerEvent, arg: number) {
@@ -70,13 +75,12 @@ export class ConfigBus {
                     encoding: 'utf8',
                   })
                   var o: Islave = parse(src)
-                  if(o.specificationid && o.specificationid.length){
+                  if (o.specificationid && o.specificationid.length) {
                     ConfigBus.busses[ConfigBus.busses.length - 1].slaves.push(o)
                     ConfigBus.emitSlaveEvent(
                       ConfigListenerEvent.addSlave,
                       new Slave(busid, o, Config.getConfiguration().mqttbasetopic)
                     )
-        
                   }
                 }
               })
@@ -135,7 +139,7 @@ export class ConfigBus {
       if (b.busId > maxBusId) maxBusId = b.busId
     })
     maxBusId++
-    log.log(LogLevelEnum.notice, "AddBusProperties: " + maxBusId)
+    log.log(LogLevelEnum.notice, 'AddBusProperties: ' + maxBusId)
     let busArrayIndex =
       ConfigBus.busses.push({
         busId: maxBusId,

--- a/src/configbus.ts
+++ b/src/configbus.ts
@@ -206,6 +206,11 @@ export class ConfigBus {
         if (deletables.includes(prop)) delete (o as any)[prop]
       }
     }
+    if( o.noDiscovery != undefined && o.noDiscovery == false )
+      delete (o as any).noDiscovery
+    if( o.noDiscoverEntities != undefined && o.noDiscoverEntities.length == 0 )
+      delete (o as any).noDiscoverEntities
+
     let s = stringify(o)
     fs.writeFileSync(newFilePath, s, { encoding: 'utf8' })
     if (oldFilePath !== newFilePath && fs.existsSync(oldFilePath))

--- a/src/configbus.ts
+++ b/src/configbus.ts
@@ -206,10 +206,8 @@ export class ConfigBus {
         if (deletables.includes(prop)) delete (o as any)[prop]
       }
     }
-    if( o.noDiscovery != undefined && o.noDiscovery == false )
-      delete (o as any).noDiscovery
-    if( o.noDiscoverEntities != undefined && o.noDiscoverEntities.length == 0 )
-      delete (o as any).noDiscoverEntities
+    if (o.noDiscovery != undefined && o.noDiscovery == false) delete (o as any).noDiscovery
+    if (o.noDiscoverEntities != undefined && o.noDiscoverEntities.length == 0) delete (o as any).noDiscoverEntities
 
     let s = stringify(o)
     fs.writeFileSync(newFilePath, s, { encoding: 'utf8' })

--- a/src/httpServerBase.ts
+++ b/src/httpServerBase.ts
@@ -272,10 +272,10 @@ export class HttpServerBase {
     this.app.use(bodyparser.json())
     this.app.use(bodyparser.urlencoded({ extended: true }))
     this.app.use(express.json())
-    this.app.use(this.processStaticAngularFiles.bind(this))
     //@ts-ignore
     this.app.use(function (_undefined: any, res: http.ServerResponse, next: any) {
       //            res.setHeader('charset', 'utf-8')
+      debug('Authenticate')
       res.setHeader('Access-Control-Allow-Methods', 'POST, PUT, OPTIONS, DELETE, GET')
       res.setHeader('Access-Control-Allow-Origin', '*')
       res.setHeader(
@@ -292,6 +292,7 @@ export class HttpServerBase {
       res.redirect('index.html')
     })
     this.initApp()
+    this.app.use(this.processStaticAngularFiles.bind(this))
     this.app.all(/.*/, this.processAll.bind(this))
     this.app.on('connection', function (socket: any) {
       socket.setTimeout(2 * 60 * 1000)

--- a/src/httpServerBase.ts
+++ b/src/httpServerBase.ts
@@ -12,6 +12,7 @@ import { LogLevelEnum, Logger } from '@modbus2mqtt/specification'
 
 import { apiUri } from '@modbus2mqtt/server.shared'
 import { AddressInfo } from 'net'
+import { MqttDiscover } from './mqttdiscover'
 
 interface IAddonInfo {
   slug: string
@@ -127,7 +128,17 @@ export class HttpServerBase {
     let token = HttpServerBase.getAuthTokenFromUrl(req.url)
     if (token != undefined) req.url = req.url.replace(token + '/', '')
     else token = HttpServerBase.getAuthTokenFromHeader(req)
-    if (req.url.indexOf('/api/') >= 0 || req.url.indexOf('/user/register') >= 0 || req.url.indexOf('/download/') >= 0) {
+    let slaveTopicFound =
+      null !=
+      MqttDiscover.getInstance()
+        .getSlaveBaseTopics()
+        .find((tp) => tp.startsWith(req.url.substring(1)))
+    if (
+      req.url.indexOf('/api/') >= 0 ||
+      req.url.indexOf('/user/register') >= 0 ||
+      req.url.indexOf('/download/') >= 0 ||
+      slaveTopicFound
+    ) {
       let authStatus = Config.getAuthStatus()
       if (authStatus.hassiotoken) {
         let address = (req.socket.address() as AddressInfo).address

--- a/src/httpserver.ts
+++ b/src/httpserver.ts
@@ -1,5 +1,6 @@
 import Debug from 'debug'
 import * as http from 'http'
+import os from 'os'
 import { Request } from 'express'
 import * as express from 'express'
 import { ConverterMap, M2mGitHub } from '@modbus2mqtt/specification'
@@ -323,6 +324,8 @@ export class HttpServer extends HttpServerBase {
       debug('configuration')
       try {
         let config = Config.getConfiguration()
+        if( Config.getAuthStatus().hassiotoken )
+          config.rootUrl = "http://" + os.hostname() + ":" + config.httpport + "/"
         this.returnResult(req, res, HttpErrorsEnum.OK, JSON.stringify(config))
       } catch (e) {
         log.log(LogLevelEnum.error, 'Error getConfiguration: ' + JSON.stringify(e))

--- a/src/httpserver.ts
+++ b/src/httpserver.ts
@@ -76,7 +76,7 @@ export class HttpServer extends HttpServerBase {
       }
     super.returnResult(req, res, code, message, object)
   }
-  handleSlaveTopics(req: Request, res: http.ServerResponse, next: any):any {
+  handleSlaveTopics(req: Request, res: http.ServerResponse, next: any): any {
     let md = MqttDiscover.getInstance()
     let url = req.url.substring(1)
     let slave = md.getSlave(url)
@@ -88,23 +88,22 @@ export class HttpServer extends HttpServerBase {
           this.returnResult(req, res, HttpErrorsEnum.OK, payload)
           return
         })
-      } else if (req.method == 'GET' && (url.indexOf('/set/')!= -1 || url.indexOf('/setModbus/')!= -1)) {
+      } else if (req.method == 'GET' && (url.indexOf('/set/') != -1 || url.indexOf('/set/modbus/') != -1)) {
         let idx = url.indexOf('/set/')
         let postLength = 5
-        if( idx == -1 ){
-          idx = url.indexOf('/setModbus/')
+        if (idx == -1) {
+          idx = url.indexOf('/set/modbus/')
           postLength = 11
         }
-        if( idx == -1)
-          return next() //should not happen
-        md.sendEntityCommand(slave, url.substring(0, idx+postLength), url.substring(idx+postLength))
+        if (idx == -1) return next() //should not happen
+        md.sendEntityCommandWithPublish(slave, url, url.substring(idx + postLength))
           .then(() => {
             this.returnResult(req, res, HttpErrorsEnum.OK, JSON.stringify({ result: 'OK' }))
           })
           .catch((e) => {
             this.returnResult(req, res, HttpErrorsEnum.ErrBadRequest, JSON.stringify({ result: e.message }))
           })
-      } else if (req.method == 'POST' && url.indexOf('/set/')!= -1 ){
+      } else if (req.method == 'POST' && url.indexOf('/set/') != -1) {
         md.sendCommand(slave, JSON.stringify(req.body))
           .then(() => {
             this.returnResult(req, res, HttpErrorsEnum.OK, JSON.stringify({ result: 'OK' }))
@@ -112,10 +111,7 @@ export class HttpServer extends HttpServerBase {
           .catch((e) => {
             this.returnResult(req, res, HttpErrorsEnum.ErrBadRequest, JSON.stringify({ result: e.message }))
           })
-
-      }
-      else
-        return next()
+      } else return next()
     } else return next()
   }
 

--- a/src/httpserver.ts
+++ b/src/httpserver.ts
@@ -324,8 +324,7 @@ export class HttpServer extends HttpServerBase {
       debug('configuration')
       try {
         let config = Config.getConfiguration()
-        if( Config.getAuthStatus().hassiotoken )
-          config.rootUrl = "http://" + os.hostname() + ":" + config.httpport + "/"
+        if (Config.getAuthStatus().hassiotoken) config.rootUrl = 'http://' + os.hostname() + ':' + config.httpport + '/'
         this.returnResult(req, res, HttpErrorsEnum.OK, JSON.stringify(config))
       } catch (e) {
         log.log(LogLevelEnum.error, 'Error getConfiguration: ' + JSON.stringify(e))

--- a/src/httpserver.ts
+++ b/src/httpserver.ts
@@ -76,6 +76,36 @@ export class HttpServer extends HttpServerBase {
       }
     super.returnResult(req, res, code, message, object)
   }
+  handleSlaveTopics(req: Request, res: http.ServerResponse, next: any):any {
+    let md = MqttDiscover.getInstance()
+    let url = req.url.substring(1)
+    let slave = md.getSlave(url)
+    if (slave) {
+      if (req.method == 'GET' && url.endsWith('/state/')) {
+        let md = new Modbus()
+        MqttDiscover.readModbus(slave)?.subscribe((spec) => {
+          let payload = slave.getStatePayload(spec.entities)
+          this.returnResult(req, res, HttpErrorsEnum.OK, payload)
+        })
+      } else if (req.method == 'GET' && url.indexOf('/set')!= -1) {
+        let idx = url.indexOf('/set/')
+        let postLength = 5
+        if( idx == -1 ){
+          idx = url.indexOf('/setModbus/')
+          postLength = 11
+        }
+        if( idx == -1)
+          return next() //should not happen
+        md.sendCommand(slave, url.substring(0, idx+postLength), url.substring(idx+postLength))
+          .then(() => {
+            this.returnResult(req, res, HttpErrorsEnum.OK, JSON.stringify({ result: 'OK' }))
+          })
+          .catch((e) => {
+            this.returnResult(req, res, HttpErrorsEnum.ErrBadRequest, JSON.stringify({ result: e.message }))
+          })
+      } else return next()
+    } else return next()
+  }
 
   modbusCacheAvailable: boolean = false
   setModbusCacheAvailable() {
@@ -94,6 +124,7 @@ export class HttpServer extends HttpServerBase {
       this.app.use('/' + filesUrlPrefix, express.static(localdir))
       this.app.use('/' + filesUrlPrefix, express.static(publicdir))
     }
+    this.app.use(this.handleSlaveTopics.bind(this))
     //@ts-ignore
     // app.use(function (err:any, req:any, res:any, next:any) {
     //     res.status(409).json({status: err.status, message: err.message})
@@ -363,8 +394,8 @@ export class HttpServer extends HttpServerBase {
               if (pullRequest.merged) log.log(LogLevelEnum.notice, 'Merged ' + pullRequest.pullNumber)
               else if (pullRequest.closed) log.log(LogLevelEnum.notice, 'Closed ' + pullRequest.pullNumber)
               else debug('Polled pullrequest ' + pullRequest.pullNumber)
-            
-              if( pullRequest.merged|| pullRequest.closed)
+
+              if (pullRequest.merged || pullRequest.closed)
                 this.returnResult(req, res, HttpErrorsEnum.OkCreated, JSON.stringify(response))
             })
           })
@@ -482,8 +513,7 @@ export class HttpServer extends HttpServerBase {
         let mqttValue = req.query.mqttValue
         let entityid = req.query.entityid ? parseInt(req.query.entityid) : undefined
         if (entityid && mqttValue)
-          new Modbus()
-            .writeEntityMqtt(bus, Number.parseInt(req.query.slaveid), req.body, entityid, mqttValue)
+          Modbus.writeEntityMqtt(bus, Number.parseInt(req.query.slaveid), req.body, entityid, mqttValue)
             .then(() => {
               this.returnResult(req, res, HttpErrorsEnum.OkCreated, '')
             })
@@ -597,9 +627,9 @@ export class HttpServer extends HttpServerBase {
           if (req.body) {
             // req.body.documents
             let config = new ConfigSpecification()
-            config.appendSpecificationUrls(req.query.specification!, [req.body]).then(files=>{
+            config.appendSpecificationUrls(req.query.specification!, [req.body]).then((files) => {
               if (files) this.returnResult(req, res, HttpErrorsEnum.OkCreated, JSON.stringify(files))
-                else this.returnResult(req, res, HttpErrorsEnum.ErrBadRequest, ' specification not found')    
+              else this.returnResult(req, res, HttpErrorsEnum.ErrBadRequest, ' specification not found')
             })
           } else {
             this.returnResult(req, res, HttpErrorsEnum.ErrBadRequest, ' specification not found')
@@ -628,13 +658,15 @@ export class HttpServer extends HttpServerBase {
           debug('Files uploaded')
           if (req.files) {
             // req.body.documents
-            let config = new ConfigSpecification();
-            let f:string[] = [];
-            (req.files as Express.Multer.File[])!.forEach((f0:any) => {f.push(f0.originalname)});
-            config.appendSpecificationFiles(req.query.specification!, f, req.query.usage!).then(files=>{
-                if (files) this.returnResult(req, res, HttpErrorsEnum.OkCreated, JSON.stringify(files))
-                  else this.returnResult(req, res, HttpErrorsEnum.OkNoContent, ' specification not found or no files passed')      
-              })
+            let config = new ConfigSpecification()
+            let f: string[] = []
+            ;(req.files as Express.Multer.File[])!.forEach((f0: any) => {
+              f.push(f0.originalname)
+            })
+            config.appendSpecificationFiles(req.query.specification!, f, req.query.usage!).then((files) => {
+              if (files) this.returnResult(req, res, HttpErrorsEnum.OkCreated, JSON.stringify(files))
+              else this.returnResult(req, res, HttpErrorsEnum.OkNoContent, ' specification not found or no files passed')
+            })
           } else {
             this.returnResult(req, res, HttpErrorsEnum.OkNoContent, ' specification not found or no files passed')
           }

--- a/src/m2m.code-workspace
+++ b/src/m2m.code-workspace
@@ -1,6 +1,7 @@
 {
 	"folders": [
 		{
+			"name": "m2m",
 			"path": "../.."
 		},
 		{
@@ -26,7 +27,7 @@
 	],
 	"settings": {
 		"jest.disabledWorkspaceFolders": [
-			"m2m"
+			"m2m", "specification.shared", "server.shared", "angular"
 		]
 	}
 }

--- a/src/modbus.ts
+++ b/src/modbus.ts
@@ -16,7 +16,7 @@ const log = new Logger('modbus')
 export class Modbus {
   constructor() {}
 
-  writeEntityModbus(bus: Bus, slaveid: number, entity: Ientity, modbusValue: ReadRegisterResult): Promise<void> {
+  static writeEntityModbus(bus: Bus, slaveid: number, entity: Ientity, modbusValue: ReadRegisterResult): Promise<void> {
     // this.modbusClient.setID(device.slaveid);
     if (Config.getConfiguration().fakeModbus) {
       return new Promise<void>((resolve) => {
@@ -34,7 +34,7 @@ export class Modbus {
     throw new Error('No modbusaddress or registerType passed')
   }
 
-  writeEntityMqtt(bus: Bus, slaveid: number, spec: Ispecification, entityid: number, mqttValue: string): Promise<void> {
+  static writeEntityMqtt(bus: Bus, slaveid: number, spec: Ispecification, entityid: number, mqttValue: string): Promise<void> {
     // this.modbusClient.setID(device.slaveid);
     let entity = spec.entities.find((ent) => ent.id == entityid)
     if (Config.getConfiguration().fakeModbus) {

--- a/src/modbus2mqtt.ts
+++ b/src/modbus2mqtt.ts
@@ -126,7 +126,6 @@ export class Modbus2Mqtt {
                 }
               })
             })
-    
           })
           .catch((e) => {
             log.log(LogLevelEnum.error, 'Start polling Contributions: ' + e.message)

--- a/src/modbus2mqtt.ts
+++ b/src/modbus2mqtt.ts
@@ -97,39 +97,41 @@ export class Modbus2Mqtt {
           Config.getConfiguration().githubPersonalToken ? Config.getConfiguration().githubPersonalToken! : null,
           join(ConfigSpecification.yamlDir, 'public')
         )
+        let startServer = ()=>{
+          let md = MqttDiscover.getInstance()
+          ConfigBus.readBusses()
+          this.pollTasks()
+          debugAction('readBussesFromConfig done')
+          debug('Inititialize busses done')
+          //execute every 30 minutes
+          setInterval(
+            () => {
+              this.pollTasks()
+            },
+            30 * 1000 * 60
+          )
+          httpServer.init().then(() => {
+            httpServer.app.listen(Config.getConfiguration().httpport, () => {
+              log.log(LogLevelEnum.notice, `modbus2mqtt listening on  ${os.hostname()}: ${Config.getConfiguration().httpport}`)
+              new ConfigSpecification().deleteNewSpecificationFiles()
+              Bus.getAllAvailableModusData()
+              if (process.env.MODBUS_NOPOLL == undefined) {
+                md.startPolling()
+              } else {
+                log.log(LogLevelEnum.notice, 'Poll disabled by environment variable MODBUS_POLL')
+              }
+            })
+        })
+        .catch((e) => {
+          log.log(LogLevelEnum.error, 'Start polling Contributions: ' + e.message)
+        })
 
+        }
         let httpServer = new HttpServer(angulardir)
         debugAction('readBussesFromConfig starts')
         gh.init()
-          .then(() => {
-            let md = MqttDiscover.getInstance()
-            ConfigBus.readBusses()
-            this.pollTasks()
-            debugAction('readBussesFromConfig done')
-            debug('Inititialize busses done')
-            //execute every 30 minutes
-            setInterval(
-              () => {
-                this.pollTasks()
-              },
-              30 * 1000 * 60
-            )
-            httpServer.init().then(() => {
-              httpServer.app.listen(Config.getConfiguration().httpport, () => {
-                log.log(LogLevelEnum.notice, `modbus2mqtt listening on  ${os.hostname()}: ${Config.getConfiguration().httpport}`)
-                new ConfigSpecification().deleteNewSpecificationFiles()
-                Bus.getAllAvailableModusData()
-                if (process.env.MODBUS_NOPOLL == undefined) {
-                  md.startPolling()
-                } else {
-                  log.log(LogLevelEnum.notice, 'Poll disabled by environment variable MODBUS_POLL')
-                }
-              })
-            })
-          })
-          .catch((e) => {
-            log.log(LogLevelEnum.error, 'Start polling Contributions: ' + e.message)
-          })
+          .then(startServer)
+          .catch(e=>{startServer}) 
       })
   }
 }

--- a/src/modbus2mqtt.ts
+++ b/src/modbus2mqtt.ts
@@ -97,7 +97,7 @@ export class Modbus2Mqtt {
           Config.getConfiguration().githubPersonalToken ? Config.getConfiguration().githubPersonalToken! : null,
           join(ConfigSpecification.yamlDir, 'public')
         )
-        let startServer = ()=>{
+        let startServer = () => {
           let md = MqttDiscover.getInstance()
           ConfigBus.readBusses()
           this.pollTasks()
@@ -110,28 +110,31 @@ export class Modbus2Mqtt {
             },
             30 * 1000 * 60
           )
-          httpServer.init().then(() => {
-            httpServer.app.listen(Config.getConfiguration().httpport, () => {
-              log.log(LogLevelEnum.notice, `modbus2mqtt listening on  ${os.hostname()}: ${Config.getConfiguration().httpport}`)
-              new ConfigSpecification().deleteNewSpecificationFiles()
-              Bus.getAllAvailableModusData()
-              if (process.env.MODBUS_NOPOLL == undefined) {
-                md.startPolling()
-              } else {
-                log.log(LogLevelEnum.notice, 'Poll disabled by environment variable MODBUS_POLL')
-              }
+          httpServer
+            .init()
+            .then(() => {
+              httpServer.app.listen(Config.getConfiguration().httpport, () => {
+                log.log(LogLevelEnum.notice, `modbus2mqtt listening on  ${os.hostname()}: ${Config.getConfiguration().httpport}`)
+                new ConfigSpecification().deleteNewSpecificationFiles()
+                Bus.getAllAvailableModusData()
+                if (process.env.MODBUS_NOPOLL == undefined) {
+                  md.startPolling()
+                } else {
+                  log.log(LogLevelEnum.notice, 'Poll disabled by environment variable MODBUS_POLL')
+                }
+              })
             })
-        })
-        .catch((e) => {
-          log.log(LogLevelEnum.error, 'Start polling Contributions: ' + e.message)
-        })
-
+            .catch((e) => {
+              log.log(LogLevelEnum.error, 'Start polling Contributions: ' + e.message)
+            })
         }
         let httpServer = new HttpServer(angulardir)
         debugAction('readBussesFromConfig starts')
         gh.init()
           .then(startServer)
-          .catch(e=>{startServer}) 
+          .catch((e) => {
+            startServer
+          })
       })
   }
 }

--- a/src/mqttdiscover.ts
+++ b/src/mqttdiscover.ts
@@ -458,7 +458,7 @@ export class MqttDiscover {
                     {
                       tAndPs.push({topic: tp.topic, payload:tp.payload, entityid:0 }) // write entity
                       debug('====================== publish done ' + tp.topic)
-                    } else log.log(LogLevelEnum.error, 'MQTT client disconnected')
+                    }
                 })
               }
               this.getMqttClient()
@@ -674,7 +674,7 @@ export class MqttDiscover {
   }
   private generateQos(slave: Slave, spec?: Ispecification): QoS {
     let qos = slave.getQos()
-    if (qos == undefined && spec != undefined)
+    if ((qos == undefined || qos == -1) && spec != undefined)
       if (spec.entities.find((e) => e.readonly == false) != undefined) return 1
       else return 0
 
@@ -690,12 +690,12 @@ export class MqttDiscover {
             mqttClient.publish(topic, slave.getStatePayload(spec.entities), { qos: this.generateQos(slave, spec) })
             mqttClient.publish(slave.getAvailabilityTopic(), 'online', { qos: this.generateQos(slave, spec) })
             resolve()
-          } catch (e) {
+          } catch (e:any) {
             try {
               mqttClient.publish(slave.getAvailabilityTopic(), 'offline', { qos: this.generateQos(slave, spec) })
-            } catch (e) {
+            } catch (e:any) {
               // ignore the error
-              debug('Error')
+              debug('Error ' + e.message)
             }
           }
         } else {

--- a/src/mqttdiscover.ts
+++ b/src/mqttdiscover.ts
@@ -466,7 +466,7 @@ export class MqttDiscover {
         debugMqttClient( format(message, args))
       }
       opts.clean = false
-      opts.clientId = 'modbus2mqtt'  
+      opts.clientId = Config.getConfiguration().mqttbasetopic
       if (opts.ca == undefined) delete opts.ca
       if (opts.key == undefined) delete opts.key
       if (opts.cert == undefined) delete opts.cert

--- a/src/mqttdiscover.ts
+++ b/src/mqttdiscover.ts
@@ -390,7 +390,7 @@ export class MqttDiscover {
         else {
            if (topic == s.getCommandTopic())
             return this.sendCommand(s, payload.toString('utf-8')) as any as Promise<void>
-           else if (topic.startsWith(s.getBaseTopic()) && topic.indexOf("/set/") ) {
+           else if (topic.startsWith(s.getBaseTopic()) && topic.indexOf("/set/") != -1) {
             return this.sendEntityCommandWithPublish(s, topic, payload.toString('utf-8')) as any as Promise<void>
           }
         }

--- a/src/mqttdiscover.ts
+++ b/src/mqttdiscover.ts
@@ -465,7 +465,7 @@ export class MqttDiscover {
         let message = args.shift()
         debugMqttClient( format(message, args))
       }
-      opts.clean = true
+      opts.clean = false
       opts.clientId = 'modbus2mqtt'  
       if (opts.ca == undefined) delete opts.ca
       if (opts.key == undefined) delete opts.key


### PR DESCRIPTION
Fixes:
 - #68
 - Discovery: Discovery uses QOS 1 for most of the topics
 
Features:
 - Disable Discovery for all and for selected topics
 - Web Service to get state synchronously with error handling
 - Decimal Precision for numbers
 - Discovery Expansion panel to deselect entities for discovery