### PR TITLE
[bug]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes

### DIFF
--- a/cypress/servers/killTestServers
+++ b/cypress/servers/killTestServers
@@ -16,6 +16,8 @@ do
      then
         kill -2 $PPID
         echo killed SIGINT $NAME 1>&2
+        sleep 0.1
+        kill $PID        
      else
        if [ $OWNER -eq `id -u` ]
        then
@@ -26,4 +28,5 @@ do
   fi
 done
 done
+netstat -pl | grep -e ":3001" -e ":3003" -e ":3004" -e ":3005"
 exit 0

--- a/src/mqttpoller.ts
+++ b/src/mqttpoller.ts
@@ -31,9 +31,10 @@ export class MqttPoller {
         if (slave.pollMode != PollModes.noPoll) {
           let sl = new Slave(bus.getId(), slave, Config.getConfiguration().mqttbasetopic)
           let pc: IslavePollInfo | undefined = this.slavePollInfo.get(sl.getSlaveId())
-
-          if (pc == undefined || pc.count > (slave.pollInterval != undefined ? slave.pollInterval / 100 : defaultPollCount))
+          if (pc == undefined)
             pc = { count: 0, processing: false }
+          if ( pc.count > (slave.pollInterval != undefined ? slave.pollInterval / 100 : defaultPollCount))
+            pc.count = 0
           if (pc.count == 0 && !pc.processing) {
             let s = new Slave(bus.getId(), slave, Config.getConfiguration().mqttbasetopic)
             if (slave.specification) {


### PR DESCRIPTION
Fixed:
- Slave UI: Specification detection did not work.
- Error Handling: Too many restarts, to many error handling slowed detection down
- Slave UI: detect specifications for new Slaves only.
- Bus: Added support for TCP RTU bridge
- Slave UI: Load complete list of specifications before spec detection
- Modbus: Use same cache for a given busid even if the Bus was recreated
### Dependant Pullrequests
|Repository|Pull Request|
|----|----|
|[specification.shared](https://github.com/modbus2mqtt/specification.shared/pulls/5)|5|
|[specification](https://github.com/modbus2mqtt/specification/pulls/7)|7|
|[angular](https://github.com/modbus2mqtt/angular/pulls/8)|8|
|[server](https://github.com/modbus2mqtt/server/pulls/114)|114|
