### PR TITLE
Modbus RTU Bridge: One configured RTU (Mod)bus can be used as Modbus TCP slave

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,24 @@
       "type": "node"
     },
     {
+       "name": "Run TCP Bridge",
+      "preLaunchTask": "npm: build.dev",
+      "timeout": 10000,
+      "program": "${workspaceFolder}/dist/modbus2mqtt.js",
+      "args": [  "-s", "../ssl", "-y" ,"../yaml-dir-bridge"],
+      "console": "integratedTerminal",
+      "env": {
+        "DEBUG": "",
+        "NODE_OPTIONS": "--experimental-vm-modules npx jest"
+      },
+      "request": "launch",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "sourceMaps": true,  
+      "type": "node"
+    },
+    {
       "name": "Test ModbusRTU",
      "timeout": 10000,
      "program": "${workspaceFolder}/__tests__/testmodbus.js",

--- a/__tests__/tcprtubridge_test.tsx
+++ b/__tests__/tcprtubridge_test.tsx
@@ -1,74 +1,81 @@
-import { it, expect } from '@jest/globals'
+import { it, expect, describe, beforeAll, afterAll, beforeEach, afterEach } from '@jest/globals'
 import { ModbusTcpRtuBridge } from '../src/tcprtubridge'
 import { ModbusRTUQueue } from '../src/modbusRTUqueue'
 import { ModbusRegisterType } from '@modbus2mqtt/specification.shared'
 import { FakeBus, ModbusRTUWorkerForTest } from './testhelper'
 import ModbusRTU from 'modbus-serial'
 import exp from 'constants'
+import { Mutex } from 'async-mutex'
 
 it('getCoil', () => {
   let queue = new ModbusRTUQueue()
   let bridge = new ModbusTcpRtuBridge(queue)
-  ;(bridge['vector']!.getCoil as (addr: number, unitID: number) => Promise<boolean>)(1, 2)
-  expect(queue.getLength()).toBe(1)
-  expect(queue.getEntries()[0].address.address).toBe(1)
-  expect(queue.getEntries()[0].slaveId).toBe(2)
-  expect(queue.getEntries()[0].address.length).toBe(1)
-  expect(queue.getEntries()[0].address.registerType).toBe(ModbusRegisterType.Coils)
+  bridge['vector']!.getCoil!(1, 2, (err, value) => {
+    expect(queue.getLength()).toBe(1)
+    expect(queue.getEntries()[0].address.address).toBe(1)
+    expect(queue.getEntries()[0].slaveId).toBe(2)
+    expect(queue.getEntries()[0].address.length).toBe(1)
+    expect(queue.getEntries()[0].address.registerType).toBe(ModbusRegisterType.Coils)
+  })
 })
 it('getDiscreteInput', () => {
   let queue = new ModbusRTUQueue()
   let bridge = new ModbusTcpRtuBridge(queue)
-  ;(bridge['vector']!.getDiscreteInput as (addr: number, unitID: number) => Promise<boolean>)(1, 2)
-  expect(queue.getLength()).toBe(1)
-  expect(queue.getEntries()[0].address.address).toBe(1)
-  expect(queue.getEntries()[0].slaveId).toBe(2)
-  expect(queue.getEntries()[0].address.length).toBe(1)
-  expect(queue.getEntries()[0].address.registerType).toBe(ModbusRegisterType.DiscreteInputs)
+  bridge['vector']!.getDiscreteInput!(1, 2, (err, value) => {
+    expect(queue.getLength()).toBe(1)
+    expect(queue.getEntries()[0].address.address).toBe(1)
+    expect(queue.getEntries()[0].slaveId).toBe(2)
+    expect(queue.getEntries()[0].address.length).toBe(1)
+    expect(queue.getEntries()[0].address.registerType).toBe(ModbusRegisterType.DiscreteInputs)
+  })
 })
 it('setCoil', () => {
   let queue = new ModbusRTUQueue()
   let bridge = new ModbusTcpRtuBridge(queue)
-  ;(bridge['vector']!.setCoil as (addr: number, v: boolean, unitID: number) => Promise<boolean>)(1, true, 2)
-  expect(queue.getLength()).toBe(1)
-  expect(queue.getEntries()[0].address.address).toBe(1)
-  expect(queue.getEntries()[0].slaveId).toBe(2)
-  expect(queue.getEntries()[0].address.length).toBe(1)
-  expect(queue.getEntries()[0].address.registerType).toBe(ModbusRegisterType.Coils)
-  expect(queue.getEntries()[0].address.write).toEqual([1])
+  bridge['vector']!.setCoil!(1, true, 2, (err) => {
+    expect(queue.getLength()).toBe(1)
+    expect(queue.getEntries()[0].address.address).toBe(1)
+    expect(queue.getEntries()[0].slaveId).toBe(2)
+    expect(queue.getEntries()[0].address.length).toBe(1)
+    expect(queue.getEntries()[0].address.registerType).toBe(ModbusRegisterType.Coils)
+    expect(queue.getEntries()[0].address.write).toEqual([1])
+  })
 })
 it('setRegister', () => {
   let queue = new ModbusRTUQueue()
   let bridge = new ModbusTcpRtuBridge(queue)
-  ;(bridge['vector']!.setRegister as (addr: number, v: number, unitID: number) => Promise<boolean>)(1, 27, 2)
-  expect(queue.getLength()).toBe(1)
-  expect(queue.getEntries()[0].address.address).toBe(1)
-  expect(queue.getEntries()[0].slaveId).toBe(2)
-  expect(queue.getEntries()[0].address.length).toBe(1)
-  expect(queue.getEntries()[0].address.registerType).toBe(ModbusRegisterType.HoldingRegister)
-  expect(queue.getEntries()[0].address.write).toEqual([27])
+  bridge['vector']!.setRegister!(1, 27, 2, (err) => {
+    expect(queue.getLength()).toBe(1)
+    expect(queue.getEntries()[0].address.address).toBe(1)
+    expect(queue.getEntries()[0].slaveId).toBe(2)
+    expect(queue.getEntries()[0].address.length).toBe(1)
+    expect(queue.getEntries()[0].address.registerType).toBe(ModbusRegisterType.HoldingRegister)
+    expect(queue.getEntries()[0].address.write).toEqual([27])
+  })
 })
 it('getHoldingRegister', () => {
   let queue = new ModbusRTUQueue()
   let bridge = new ModbusTcpRtuBridge(queue)
-  ;(bridge['vector']!.getHoldingRegister as (addr: number, unitID: number) => Promise<boolean>)(1, 2)
-  expect(queue.getLength()).toBe(1)
-  expect(queue.getEntries()[0].address.address).toBe(1)
-  expect(queue.getEntries()[0].slaveId).toBe(2)
-  expect(queue.getEntries()[0].address.length).toBe(1)
-  expect(queue.getEntries()[0].address.registerType).toBe(ModbusRegisterType.HoldingRegister)
-  expect(queue.getEntries()[0].address.write).not.toBeDefined()
+  bridge['vector']!.getHoldingRegister!(1, 2, (err, value) => {
+    expect(queue.getLength()).toBe(1)
+    expect(queue.getEntries()[0].address.address).toBe(1)
+    expect(queue.getEntries()[0].slaveId).toBe(2)
+    expect(queue.getEntries()[0].address.length).toBe(1)
+    expect(queue.getEntries()[0].address.registerType).toBe(ModbusRegisterType.HoldingRegister)
+    expect(queue.getEntries()[0].address.write).not.toBeDefined()
+  })
 })
 it('getInputRegister', () => {
   let queue = new ModbusRTUQueue()
   let bridge = new ModbusTcpRtuBridge(queue)
-  ;(bridge['vector']!.getInputRegister as (addr: number, unitID: number) => Promise<boolean>)(1, 2)
-  expect(queue.getLength()).toBe(1)
-  expect(queue.getEntries()[0].address.address).toBe(1)
-  expect(queue.getEntries()[0].slaveId).toBe(2)
-  expect(queue.getEntries()[0].address.length).toBe(1)
-  expect(queue.getEntries()[0].address.registerType).toBe(ModbusRegisterType.AnalogInputs)
-  expect(queue.getEntries()[0].address.write).not.toBeDefined()
+  bridge['vector']!.getInputRegister!(1, 2, (err, value) => {
+    expect(queue.getLength()).toBe(1)
+    expect(queue.getEntries()[0].address.address).toBe(1)
+    expect(queue.getEntries()[0].slaveId).toBe(2)
+    expect(queue.getEntries()[0].address.length).toBe(1)
+    expect(queue.getEntries()[0].address.registerType).toBe(ModbusRegisterType.AnalogInputs)
+    expect(queue.getEntries()[0].address.write).not.toBeDefined()
+  })
 })
 it('getMultipleHoldingRegisters', () => {
   let queue = new ModbusRTUQueue()
@@ -97,32 +104,72 @@ it('getMultipleInputRegisters', (done) => {
   queue.getEntries()[0].onResolve(queue.getEntries()[0], [198, 198, 198])
 })
 
-it('start/stop live test', (done) => {
-  let queue = new ModbusRTUQueue()
-  let fakeBus = new FakeBus()
-  new ModbusRTUWorkerForTest(fakeBus, queue, () => {}, 'start/stop')
-  let bridge = new ModbusTcpRtuBridge(queue)
+describe('live tests', () => {
   const client = new ModbusRTU()
-
-  // open connection to a tcp line
-  client.setID(1)
-  bridge
-    .startServer(3010)
-    .then(() => {
-      client.connectTCP('localhost', { port: 3010 }).then(() => {
-        // submit a request
-        client
-          .readHoldingRegisters(2, 4)
-          .then((value) => {
-            expect(value.data.length).toBe(4)
-            bridge.stopServer(done)
-          })
-          .catch((e) => {
-            expect(false).toBeTruthy()
-          })
+  let bridge: ModbusTcpRtuBridge
+  let testWorker: ModbusRTUWorkerForTest
+  let liveMutext = new Mutex()
+  beforeAll(() => {
+    return new Promise<void>((resolve) => {
+      let queue = new ModbusRTUQueue()
+      let fakeBus = new FakeBus()
+      testWorker = new ModbusRTUWorkerForTest(fakeBus, queue, () => {}, 'start/stop')
+      bridge = new ModbusTcpRtuBridge(queue)
+      // open connection to a tcp line
+      client.setID(1)
+      bridge.startServer(3010).then(() => {
+        client.connectTCP('localhost', { port: 3010 }).then(() => {
+          resolve()
+        })
       })
     })
-    .catch((e) => {
-      expect(false).toBeTruthy()
+  })
+
+  afterAll(() => {
+    bridge.stopServer()
+  })
+  it('live readHoldingRegisters', (done) => {
+    liveMutext.runExclusive(() => {
+      // submit a request
+      client
+        .readHoldingRegisters(2, 4)
+        .then((value) => {
+          expect(value.data.length).toBe(4)
+          done()
+        })
+        .catch((e) => {
+          expect(false).toBeTruthy()
+        })
     })
+  })
+  it('live readDiscreteInputs', (done) => {
+    liveMutext.runExclusive(() => {
+      // submit a request
+      client
+        .readDiscreteInputs(2, 4)
+        .then((value) => {
+          expect(value.data[0]).toBeFalsy()
+          done()
+        })
+        .catch((e) => {
+          expect(false).toBeTruthy()
+        })
+    })
+  })
+  it('live writeHoldingRegister', (done) => {
+    liveMutext.runExclusive(() => {
+      // submit a request
+      testWorker.expectedAPIcallCount = 0
+      testWorker.expectedAPIwroteDataCount = 1
+      testWorker['done'] = done
+      client
+        .writeRegister(2, 1)
+        .then(() => {
+          console.log("We are back")
+        })
+        .catch((e) => {
+          expect(false).toBeTruthy()
+        })
+    })
+  })
 })

--- a/__tests__/tcprtubridge_test.tsx
+++ b/__tests__/tcprtubridge_test.tsx
@@ -159,7 +159,7 @@ describe('live tests', () => {
   it('live writeHoldingRegister', (done) => {
     liveMutext.runExclusive(() => {
       // submit a request
-      testWorker.expectedAPIcallCount = 0
+      testWorker.expectedAPIcallCount = 1
       testWorker.expectedAPIwroteDataCount = 1
       testWorker['done'] = done
       client

--- a/src/modbusRTUprocessor.ts
+++ b/src/modbusRTUprocessor.ts
@@ -165,7 +165,9 @@ export class ModbusRTUProcessor {
                 data[0]
             )
             if (valueCount == addressCount) {
-              debugResult(ModbusTasks[options.task] + ': slaveId: ' + slaveId + ' addresses.length:' + preparedAddresses.addresses.length)
+              debugResult(
+                ModbusTasks[options.task] + ': slaveId: ' + slaveId + ' addresses.length:' + preparedAddresses.addresses.length
+              )
               resolve(values)
             }
           },

--- a/src/modbusRTUworker.ts
+++ b/src/modbusRTUworker.ts
@@ -411,15 +411,14 @@ export class ModbusRTUWorker extends ModbusWorker {
       if (this.cache.get(current.slaveId) == undefined) this.cache.set(current.slaveId, this.createEmptyIModbusValues())
       let cacheEntry = this.cache.get(current.slaveId)
       cacheEntry!.requestCount[current.options.task][dt.getMinutes()]++
-      if (current.address.write)
-        return this.functionCodeWriteMap.get(current.address.registerType)!(
-          current.slaveId,
-          current.address.address,
-          current.address.write
-        )
-          .then(() => this.processOneEntry())
-          .catch((e) => this.processOneEntry())
-      else
+      if (current.address.write) {
+        let fct = this.functionCodeWriteMap.get(current.address.registerType)
+        if (fct)
+          return fct(current.slaveId, current.address.address, current.address.write)
+            .then(() => this.processOneEntry())
+            .catch((e) => this.processOneEntry())
+        else return Promise.reject(new Error('Invalid function code for write' + current.address.registerType))
+      } else
         return this.executeModbusFunctionCodeRead(current)
           .then(() => this.processOneEntry())
           .catch((e) => this.processOneEntry())

--- a/src/tcprtubridge.ts
+++ b/src/tcprtubridge.ts
@@ -9,56 +9,85 @@ import Debug from 'debug'
 const log = new Logger('tcprtubridge')
 let debug = Debug('tcprtubridge')
 
+function queueRegister<T>(
+  queue: ModbusRTUQueue,
+  registerType: ModbusRegisterType,
+  onResolve: (value?: number[]) => T,
+  addr: number,
+  write: number[] | undefined,
+  unitID: number,
+  length: number
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let a: ImodbusAddress = { address: addr, length: length, registerType: registerType, write: write }
+    queue.enqueue(
+      unitID,
+      a,
+      (_qe: IQueueEntry, result?: number[]) => {
+        try {
+          let v = onResolve(result)
+          resolve(v)
+        } catch (e: any) {
+          reject(e)
+        }
+      },
+      (_qe: IQueueEntry, e: any) => {
+        reject(e)
+      },
+      { useCache: false, task: ModbusTasks.tcpBridge, errorHandling: {} }
+    )
+  })
+}
+function queueOneRegister<T>(
+  queue: ModbusRTUQueue,
+  registerType: ModbusRegisterType,
+  mapper: (inp: number) => T,
+  addr: number,
+  write: number[] | undefined,
+  unitID: number,
+  cb: FCallbackVal<T>
+): void {
+  let w: number[] | undefined = undefined
+  if (write != undefined) w = write
+  queueRegister<T>(
+    queue,
+    registerType,
+    (value?: number[]): T => {
+      if (value && value.length < 1) throw new Error('No value returned')
+      else return mapper(value![0])
+    },
+    addr,
+    w,
+    unitID,
+    1
+  )
+    .then((value) => {
+      debug('success: %d %d', addr, 1)
+      cb(null, value)
+    })
+    .catch((e) => {
+      // Timeout must be ignored. It will be handled on client side
+      if (e.errno && e.errno != 'ETIMEDOUT') {
+        debug('error: %d %d %s', addr, 1, e.message)
+        cb(e, mapper(-1))
+      } else debug('Ignoring timeout: %d %d %s', addr, 1, e.message)
+    })
+}
+
 export class ModbusTcpRtuBridge {
   serverTCP: ServerTCP | undefined = undefined
   constructor(private queue: ModbusRTUQueue) {}
-  queueRegister<T>(
-    registerType: ModbusRegisterType,
-    onResolve: (value?: number[]) => T,
-    addr: number,
-    write: number[] | undefined,
-    unitID: number,
-    length: number
-  ): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-      let a: ImodbusAddress = { address: addr, length: length, registerType: registerType, write: write }
-      this.queue.enqueue(
-        unitID,
-        a,
-        (_qe: IQueueEntry, result?: number[]) => {
-          try {
-            let v = onResolve(result)
-            resolve(v)
-          } catch (e: any) {
-            reject(e)
-          }
-        },
-        (_qe: IQueueEntry, e: any) => {
-          reject(e)
-        },
-        { useCache: false, task: ModbusTasks.tcpBridge, errorHandling: {} }
-      )
-    })
-  }
+
   static getDefaultPort(): number {
     return Config.getConfiguration().tcpBridgePort!
   }
-
-  queueOneRegister(registerType: ModbusRegisterType, addr: number, write: number | undefined, unitID: number): Promise<number> {
-    let w: number[] | undefined = undefined
-    if (write != undefined) w = [write]
-    return this.queueRegister<number>(
-      registerType,
-      (value?: number[]): number => {
-        if (value && value.length < 1) throw new Error('No value returned')
-        else return value![0]
-      },
-      addr,
-      w,
-      unitID,
-      1
-    )
+  private static resultMapperNumber(inp: number): number {
+    return inp
   }
+  private static resultMapperBoolean(inp: number): boolean {
+    return inp ? true : false
+  }
+
   queueMultipleRegister(
     registerType: ModbusRegisterType,
     addr: number,
@@ -66,8 +95,9 @@ export class ModbusTcpRtuBridge {
     unitID: number,
     cb: FCallbackVal<number[]>
   ): void {
-    debug("queueing: %d %d" , addr, length)
-    this.queueRegister<number[]>(
+    debug('queueing: %d %d', addr, length)
+    queueRegister<number[]>(
+      this.queue,
       registerType,
       (value?: number[]): number[] => {
         if (value == undefined) throw new Error('No value returned')
@@ -79,56 +109,86 @@ export class ModbusTcpRtuBridge {
       length
     )
       .then((value) => {
-        debug("success: %d %d" , addr, length)
+        debug('success: %d %d', addr, length)
         cb(null, value)
       })
       .catch((e) => {
         // Timeout must be ignored. It will be handled on client side
-        if ( e.errno && e.errno != 'ETIMEDOUT'){
-            debug("error: %d %d %s" , addr, length, e.message)
-            cb(e, [])
-        }else
-            debug("Ignoring timeout: %d %d %s" , addr, length, e.message)
-        
+        if (e.errno && e.errno != 'ETIMEDOUT') {
+          debug('error: %d %d %s', addr, length, e.message)
+          cb(e, [])
+        } else debug('Ignoring timeout: %d %d %s', addr, length, e.message)
       })
   }
-  queueOneBoolRegister(
-    registerType: ModbusRegisterType,
-    addr: number,
-    write: boolean | undefined,
-    unitID: number
-  ): Promise<boolean> {
-    let w: number[] | undefined = undefined
-    if (write != undefined) w = [write ? 1 : 0]
-    return this.queueRegister<boolean>(
-      registerType,
-      (value?: number[]): boolean => {
-        if (value && value.length < 1) throw new Error('No value returned')
-        else return value![0] != 0
-      },
-      addr,
-      w,
-      unitID,
-      1
-    )
-  }
   vector: IServiceVector = {
-    setRegister: this.queueOneRegister.bind(this, ModbusRegisterType.HoldingRegister),
-    setCoil: this.queueOneBoolRegister.bind(this, ModbusRegisterType.Coils),
+    setRegister: (addr: number, write: number, unit: number, cb: FCallbackVal<number>) => {
+      queueOneRegister<number>(
+        this.queue,
+        ModbusRegisterType.HoldingRegister,
+        ModbusTcpRtuBridge.resultMapperNumber,
+        addr,
+        [write],
+        unit,
+        cb
+      )
+    },
+    setCoil: (addr: number, write: boolean, unit: number, cb: FCallbackVal<boolean>) => {
+      queueOneRegister<boolean>(
+        this.queue,
+        ModbusRegisterType.Coils,
+        ModbusTcpRtuBridge.resultMapperBoolean,
+        addr,
+        [write ? 1 : 0],
+        unit,
+        cb
+      )
+    },
     getMultipleInputRegisters: this.queueMultipleRegister.bind(this, ModbusRegisterType.AnalogInputs),
     getMultipleHoldingRegisters: this.queueMultipleRegister.bind(this, ModbusRegisterType.HoldingRegister),
 
-    getInputRegister: (addr: number, unit: number) => {
-      this.queueOneRegister.bind(this, ModbusRegisterType.AnalogInputs)(addr, undefined, unit)
+    getInputRegister: (addr: number, unit: number, cb: FCallbackVal<number>) => {
+      queueOneRegister<number>(
+        this.queue,
+        ModbusRegisterType.AnalogInputs,
+        ModbusTcpRtuBridge.resultMapperNumber,
+        addr,
+        undefined,
+        unit,
+        cb
+      )
     },
-    getHoldingRegister: (addr: number, unit: number) => {
-      this.queueOneRegister.bind(this, ModbusRegisterType.HoldingRegister)(addr, undefined, unit)
+    getHoldingRegister: (addr: number, unit: number, cb: FCallbackVal<number>) => {
+      queueOneRegister<number>(
+        this.queue,
+        ModbusRegisterType.HoldingRegister,
+        ModbusTcpRtuBridge.resultMapperNumber,
+        addr,
+        undefined,
+        unit,
+        cb
+      )
     },
-    getDiscreteInput: (addr: number, unit: number) => {
-      this.queueOneBoolRegister.bind(this, ModbusRegisterType.DiscreteInputs)(addr, undefined, unit)
+    getDiscreteInput: (addr: number, unit: number, cb: FCallbackVal<boolean>) => {
+      queueOneRegister<boolean>(
+        this.queue,
+        ModbusRegisterType.DiscreteInputs,
+        ModbusTcpRtuBridge.resultMapperBoolean,
+        addr,
+        undefined,
+        unit,
+        cb
+      )
     },
-    getCoil: (addr: number, unit: number) => {
-      this.queueOneBoolRegister.bind(this, ModbusRegisterType.Coils)(addr, undefined, unit)
+    getCoil: (addr: number, unit: number, cb: FCallbackVal<boolean>) => {
+      queueOneRegister<boolean>(
+        this.queue,
+        ModbusRegisterType.Coils,
+        ModbusTcpRtuBridge.resultMapperBoolean,
+        addr,
+        undefined,
+        unit,
+        cb
+      )
     },
   }
   async startServer(port: number = ModbusTcpRtuBridge.getDefaultPort()): Promise<ServerTCP> {


### PR DESCRIPTION
### How to configure the Bridge
In order to use the RTU/TCP bridge, do the following:
in Homeassistant 
- Open the Addon Configuration of modbus2mqtt.
- Map the TCP Bridge port (502) to a host port 
In Modbus2mqtt User Interface:
-  Select the bus you want to share via TCP. 
- For this bus enable the Modbus RTU/TCP Bridge switch.
- Save the changes
### How to use it
If you want to use the TCP port, in another modbus2mqtt instance,
In Modbus2mqtt User Interface:
-  Create or Select a bus 
- Configure it for TCP: 
- Enter the host name of the bridge
- Enter the mapped port  
- Enter a timeout similar to the Bridge bus timeout
- Save

Any configured slave will use the tcp bridge to communicate to the RTU bus.

