### PR TITLE
feat: auto-detect HTTPS certificates in /ssl directory

### DIFF
--- a/backend/src/server/config.ts
+++ b/backend/src/server/config.ts
@@ -166,7 +166,11 @@ export class Config {
           : process.env.HASSIO_TOKEN != undefined && process.env.HASSIO_TOKEN.length > 0
       Config.config.supervisor_host = Config.config.supervisor_host ? Config.config.supervisor_host : 'supervisor'
 
-      // HTTPS configuration: env var takes precedence over YAML
+      // HTTPS configuration
+      // Default certificate filenames (Let's Encrypt / Home Assistant convention)
+      Config.config.httpsCertFile = Config.config.httpsCertFile ? Config.config.httpsCertFile : 'fullchain.pem'
+      Config.config.httpsKeyFile = Config.config.httpsKeyFile ? Config.config.httpsKeyFile : 'privkey.pem'
+      // Default HTTPS port; env var takes precedence over YAML
       const envHttpsPort = process.env.MODBUS2MQTT_HTTPS_PORT
       if (envHttpsPort) {
         const parsed = parseInt(envHttpsPort, 10)
@@ -174,11 +178,7 @@ export class Config {
           Config.config.httpsPort = parsed
         }
       }
-      // Default certificate filenames when HTTPS is configured
-      if (Config.config.httpsPort) {
-        Config.config.httpsCertFile = Config.config.httpsCertFile ? Config.config.httpsCertFile : 'fullchain.pem'
-        Config.config.httpsKeyFile = Config.config.httpsKeyFile ? Config.config.httpsKeyFile : 'privkey.pem'
-      }
+      Config.config.httpsPort = Config.config.httpsPort ? Config.config.httpsPort : 3443
       // Disable HTTPS in addon mode
       if (Config.config.mqttusehassio) {
         Config.config.httpsPort = undefined

--- a/backend/src/server/httpServerBase.ts
+++ b/backend/src/server/httpServerBase.ts
@@ -69,12 +69,13 @@ export class HttpServerBase {
     const httpsPort = config.httpsPort
 
     if (httpsPort) {
+      // Auto-detect: check if certificate files exist in sslDir
       const persistence = new ConfigPersistence()
       const certData = persistence.readCertificateFile(config.httpsCertFile)
       const keyData = persistence.readCertificateFile(config.httpsKeyFile)
 
       if (certData && keyData) {
-        // Start HTTPS server with the app
+        // Certificates found — start HTTPS server with the app
         this.httpsServer = https.createServer({ cert: certData, key: keyData }, this.app)
         this.httpsServer.listen(httpsPort, () => {
           log.log(LogLevelEnum.info, `HTTPS listening on port ${httpsPort}`)
@@ -94,14 +95,13 @@ export class HttpServerBase {
         return
       } else {
         log.log(
-          LogLevelEnum.warn,
-          `HTTPS configured on port ${httpsPort} but certificate files not found ` +
-            `(${config.httpsCertFile}, ${config.httpsKeyFile} in ${ConfigPersistence.sslDir}). Falling back to HTTP only.`
+          LogLevelEnum.info,
+          `HTTPS disabled: certificate files not found (${config.httpsCertFile}, ${config.httpsKeyFile} in ${ConfigPersistence.sslDir})`
         )
       }
     }
 
-    // Default: plain HTTP
+    // No HTTPS: HTTP server serves the app directly
     this.server = this.app.listen(config.httpport, listenFunction)
   }
   close() {

--- a/backend/tests/server/config_https_test.tsx
+++ b/backend/tests/server/config_https_test.tsx
@@ -1,4 +1,4 @@
-import { expect, it, describe, afterEach, beforeAll } from 'vitest'
+import { expect, it, describe, afterEach, beforeAll, afterAll } from 'vitest'
 import { Config } from '../../src/server/config.js'
 import { setConfigsDirsForTest } from './configsbase.js'
 import { TempConfigDirHelper } from './testhelper.js'
@@ -26,48 +26,45 @@ afterEach(() => {
   new Config().writeConfiguration(cfg)
 })
 
-import { afterAll } from 'vitest'
 afterAll(() => {
   if (tempHelper) tempHelper.cleanup()
 })
 
 describe('HTTPS configuration', () => {
-  it('should not set httpsPort by default', () => {
-    const cfg = Config.getConfiguration()
-    expect(cfg.httpsPort).toBeUndefined()
-  })
-
-  it('should set httpsPort from environment variable', () => {
-    process.env.MODBUS2MQTT_HTTPS_PORT = '3443'
+  it('should default httpsPort to 3443', () => {
     const cfg = Config.getConfiguration()
     expect(cfg.httpsPort).toBe(3443)
   })
 
-  it('should set default certificate filenames when httpsPort is configured', () => {
-    process.env.MODBUS2MQTT_HTTPS_PORT = '3443'
+  it('should always set default certificate filenames (Let\'s Encrypt / HA convention)', () => {
     const cfg = Config.getConfiguration()
     expect(cfg.httpsCertFile).toBe('fullchain.pem')
     expect(cfg.httpsKeyFile).toBe('privkey.pem')
   })
 
-  it('should ignore invalid MODBUS2MQTT_HTTPS_PORT values', () => {
-    process.env.MODBUS2MQTT_HTTPS_PORT = 'notanumber'
+  it('should set httpsPort from environment variable', () => {
+    process.env.MODBUS2MQTT_HTTPS_PORT = '9443'
     const cfg = Config.getConfiguration()
-    expect(cfg.httpsPort).toBeUndefined()
+    expect(cfg.httpsPort).toBe(9443)
   })
 
-  it('should ignore zero or negative MODBUS2MQTT_HTTPS_PORT', () => {
+  it('should use default port when MODBUS2MQTT_HTTPS_PORT is invalid', () => {
+    process.env.MODBUS2MQTT_HTTPS_PORT = 'notanumber'
+    const cfg = Config.getConfiguration()
+    expect(cfg.httpsPort).toBe(3443)
+  })
+
+  it('should use default port when MODBUS2MQTT_HTTPS_PORT is zero or negative', () => {
     process.env.MODBUS2MQTT_HTTPS_PORT = '0'
     const cfg = Config.getConfiguration()
-    expect(cfg.httpsPort).toBeUndefined()
+    expect(cfg.httpsPort).toBe(3443)
 
     process.env.MODBUS2MQTT_HTTPS_PORT = '-1'
     const cfg2 = Config.getConfiguration()
-    expect(cfg2.httpsPort).toBeUndefined()
+    expect(cfg2.httpsPort).toBe(3443)
   })
 
   it('should disable httpsPort in addon mode (HASSIO_TOKEN set)', () => {
-    process.env.MODBUS2MQTT_HTTPS_PORT = '3443'
     process.env.HASSIO_TOKEN = 'some-token'
     const cfg = Config.getConfiguration()
     expect(cfg.httpsPort).toBeUndefined()
@@ -82,10 +79,6 @@ describe('HTTPS configuration', () => {
     // Re-read and verify
     const cfg2 = Config.getConfiguration()
     expect(cfg2.httpsPort).toBe(8443)
-
-    // Clean up: remove httpsPort
-    cfg.httpsPort = undefined
-    new Config().writeConfiguration(cfg)
   })
 
   it('should let env var override YAML httpsPort', () => {
@@ -98,15 +91,10 @@ describe('HTTPS configuration', () => {
     process.env.MODBUS2MQTT_HTTPS_PORT = '9443'
     const cfg2 = Config.getConfiguration()
     expect(cfg2.httpsPort).toBe(9443)
-
-    // Clean up
-    cfg.httpsPort = undefined
-    new Config().writeConfiguration(cfg)
   })
 
   it('should allow custom certificate filenames', () => {
     const cfg = Config.getConfiguration()
-    cfg.httpsPort = 3443
     cfg.httpsCertFile = 'custom.crt'
     cfg.httpsKeyFile = 'custom.key'
     new Config().writeConfiguration(cfg)
@@ -114,11 +102,5 @@ describe('HTTPS configuration', () => {
     const cfg2 = Config.getConfiguration()
     expect(cfg2.httpsCertFile).toBe('custom.crt')
     expect(cfg2.httpsKeyFile).toBe('custom.key')
-
-    // Clean up
-    cfg.httpsPort = undefined
-    cfg.httpsCertFile = undefined
-    cfg.httpsKeyFile = undefined
-    new Config().writeConfiguration(cfg)
   })
 })

--- a/backend/tests/server/httpserver_https_test.tsx
+++ b/backend/tests/server/httpserver_https_test.tsx
@@ -28,11 +28,15 @@ afterAll(() => {
 afterEach(() => {
   delete process.env.MODBUS2MQTT_HTTPS_PORT
   delete process.env.HASSIO_TOKEN
+  // Remove any generated test certificates to avoid leaking between tests
+  const certPath = join(ConfigPersistence.sslDir, 'fullchain.pem')
+  const keyPath = join(ConfigPersistence.sslDir, 'privkey.pem')
+  if (fs.existsSync(certPath)) fs.unlinkSync(certPath)
+  if (fs.existsSync(keyPath)) fs.unlinkSync(keyPath)
 })
 
 /**
  * Generate self-signed certificates for testing.
- * Returns the sslDir where cert and key files are stored.
  */
 function generateTestCertificates(sslDir: string): { certFile: string; keyFile: string } {
   const certFile = 'fullchain.pem'
@@ -44,7 +48,6 @@ function generateTestCertificates(sslDir: string): { certFile: string; keyFile: 
     fs.mkdirSync(sslDir, { recursive: true })
   }
 
-  // Generate self-signed certificate using openssl
   execSync(
     `openssl req -x509 -newkey rsa:2048 -keyout "${keyPath}" -out "${certPath}" ` +
       `-days 1 -nodes -subj "/CN=localhost" 2>/dev/null`
@@ -54,7 +57,7 @@ function generateTestCertificates(sslDir: string): { certFile: string; keyFile: 
 }
 
 describe('HTTPS server', () => {
-  it('should fall back to HTTP when certificates are missing', async () => {
+  it('should serve HTTP only when no certificates exist in sslDir (auto-detection)', async () => {
     const httpPort = await getAvailablePort()
     const httpsPort = await getAvailablePort()
 
@@ -66,7 +69,6 @@ describe('HTTPS server', () => {
     const certExisted = fs.existsSync(certPath)
     const keyExisted = fs.existsSync(keyPath)
 
-    // Temporarily remove certs if they exist
     if (certExisted) fs.renameSync(certPath, certPath + '.bak')
     if (keyExisted) fs.renameSync(keyPath, keyPath + '.bak')
 
@@ -75,43 +77,42 @@ describe('HTTPS server', () => {
       cfg.httpport = httpPort
       new Config().writeConfiguration(cfg)
 
-      // Create a minimal HttpServerBase (no Angular dir needed for this test)
       const server = new HttpServerBase()
-      server['initBase'] = () => {} // Skip Angular init
+      server['app'].get('/', (_req, res) => {
+        res.status(200).send('OK')
+      })
 
       await new Promise<void>((resolve) => {
         server.listen(() => {
-          // HTTP server should be running
           expect(server.server).toBeDefined()
-          // HTTPS server should NOT be running (certs missing)
           expect(server.httpsServer).toBeUndefined()
-          server.close()
-          resolve()
+
+          http.get(`http://localhost:${httpPort}/`, (res) => {
+            expect(res.statusCode).toBe(200)
+            server.close()
+            resolve()
+          })
         })
       })
     } finally {
-      // Restore certs
       if (certExisted) fs.renameSync(certPath + '.bak', certPath)
       if (keyExisted) fs.renameSync(keyPath + '.bak', keyPath)
     }
   })
 
-  it('should start HTTPS server when certificates are available', async () => {
+  it('should auto-enable HTTPS when certificates exist in sslDir', async () => {
     const httpPort = await getAvailablePort()
     const httpsPort = await getAvailablePort()
 
-    const { certFile, keyFile } = generateTestCertificates(ConfigPersistence.sslDir)
+    generateTestCertificates(ConfigPersistence.sslDir)
 
     process.env.MODBUS2MQTT_HTTPS_PORT = String(httpsPort)
 
     const cfg = Config.getConfiguration()
     cfg.httpport = httpPort
-    cfg.httpsCertFile = certFile
-    cfg.httpsKeyFile = keyFile
     new Config().writeConfiguration(cfg)
 
     const server = new HttpServerBase()
-    // Minimal app setup so Express responds
     server['app'].get('/', (_req, res) => {
       res.status(200).send('OK')
     })
@@ -122,13 +123,13 @@ describe('HTTPS server', () => {
           expect(server.httpsServer).toBeDefined()
           expect(server.server).toBeDefined()
 
-          // Test HTTPS responds
+          // HTTPS serves the app
           const agent = new https.Agent({ rejectUnauthorized: false })
           https
             .get(`https://localhost:${httpsPort}/`, { agent }, (res) => {
               expect(res.statusCode).toBe(200)
 
-              // Test HTTP redirects
+              // HTTP redirects to HTTPS
               http.get(`http://localhost:${httpPort}/test`, (httpRes) => {
                 expect(httpRes.statusCode).toBe(301)
                 expect(httpRes.headers.location).toContain(`https://`)
@@ -149,13 +150,14 @@ describe('HTTPS server', () => {
     })
   })
 
-  it('should only start HTTP when no httpsPort is configured', async () => {
+  it('should serve HTTP only in addon mode (HASSIO_TOKEN disables HTTPS)', async () => {
     const httpPort = await getAvailablePort()
 
-    // No MODBUS2MQTT_HTTPS_PORT set
+    // Simulate addon mode — HTTPS is disabled
+    process.env.HASSIO_TOKEN = 'test-addon-token'
     const cfg = Config.getConfiguration()
     cfg.httpport = httpPort
-    cfg.httpsPort = undefined
+    expect(cfg.httpsPort).toBeUndefined()
     new Config().writeConfiguration(cfg)
 
     const server = new HttpServerBase()


### PR DESCRIPTION
## What does this PR do?
If certificates are available in /ssl directory, https will be enabled automatically.

## Tests

<!-- Bug fixes and new features must include unit tests. -->

- [X] Unit tests added/updated
