### PR TITLE
ci: use squash merges for auto-merge

### DIFF
--- a/.github/workflows/auto-merge-on-pr.yml
+++ b/.github/workflows/auto-merge-on-pr.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   auto-merge:
-    name: Enable auto-merge (rebase)
+    name: Enable auto-merge (squash)
     runs-on: ubuntu-latest
     # Only for trusted contributors (not bots, not external)
     if: >-
@@ -19,6 +19,6 @@ jobs:
       || github.actor == 'volkmarnissen') }}
     steps:
       - uses: actions/checkout@v5
-      - run: gh pr merge ${{ github.event.pull_request.number }} --auto --rebase
+      - run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash
         env:
           GH_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for auto-merging pull requests. The main change is switching the merge strategy from "rebase" to "squash" when automatically merging PRs.

Workflow configuration updates:

* Changed the job name from "Enable auto-merge (rebase)" to "Enable auto-merge (squash)" in `.github/workflows/auto-merge-on-pr.yml` to reflect the new merge strategy.
* Updated the merge command to use the `--squash` option instead of `--rebase`, so PRs will now be squashed into a single commit when merged automatically.