### PR TITLE
feat: discovery hardware version 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ web_modules/
 
 # Local SSL certificates and key material
 ssl/
+certs/
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,7 @@
       "preLaunchTask": "npm: build",
       "timeout": 10000,
       "program": "${workspaceFolder}/dist/server/modbus2mqtt.js",
-      "args": ["-s", "ssl", "-c", "../config-dir", "-d", "../data-dir"],
+      "args": ["-s", "certs", "-c", "../config-dir", "-d", "../data-dir"],
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "env": {
@@ -86,7 +86,7 @@
       "preLaunchTask": "npm: build.dev",
       "timeout": 10000,
       "program": "${workspaceFolder}/dist/server/modbus2mqtt.js",
-      "args": ["-s", "../ssl", "-y", "../yaml-dir-bridge"],
+      "args": ["-s", "certs", "-y", "../yaml-dir-bridge"],
       "console": "integratedTerminal",
       "env": {
         "DEBUG": ""

--- a/backend/src/server/mqttconnector.ts
+++ b/backend/src/server/mqttconnector.ts
@@ -64,14 +64,28 @@ export class MqttConnector {
 
   validateConnection(connectionData: ImqttClient | undefined, callback: (valid: boolean, message: string) => void) {
     if (connectionData && connectionData.mqttserverurl != undefined) {
-      const client = connect(connectionData.mqttserverurl, connectionData as IClientOptions)
+      const opts: IClientOptions = {
+        ...(connectionData as IClientOptions),
+        reconnectPeriod: 0,
+        connectTimeout: 5000,
+      }
+      const client = connect(connectionData.mqttserverurl, opts)
+      let settled = false
+      const settle = (valid: boolean, message: string) => {
+        if (settled) return
+        settled = true
+        try {
+          client.end(true)
+        } catch {
+          /* ignore */
+        }
+        callback(valid, message)
+      }
       client.on('error', (e) => {
-        client!.end(() => {})
-        callback(false, connectionData.mqttserverurl + ': ' + e.toString())
+        settle(false, connectionData.mqttserverurl + ': ' + e.toString())
       })
       client.on('connect', () => {
-        callback(true, 'OK')
-        if (client) client.end(() => {})
+        settle(true, 'OK')
       })
     } else callback(false, 'no mqttserverlurl passed')
   }

--- a/frontend/src/app/configure/configure.component.html
+++ b/frontend/src/app/configure/configure.component.html
@@ -56,20 +56,31 @@
           }
         </mat-form-field>
         <mat-form-field class="width250pt">
-          <mat-label>CA certificate File (located in HA ssl directory)</mat-label>
+          <mat-label>CA certificate file (located in ssl directory)</mat-label>
           <mat-select matInput formControlName="mqttcafile" (selectionChange)="onChangekMqttConfig()">
             @for (c of sslFiles; track $index) {
               <mat-option [value]="c">{{ c }} </mat-option>
             }
           </mat-select>
+          <mat-hint>Example: {{ defaultCaFile }}</mat-hint>
         </mat-form-field>
         <mat-form-field class="width250pt">
-          <mat-label>Client key (located in HA ssl directory) for client authentication</mat-label>
+          <mat-label>Client certificate file (located in ssl directory)</mat-label>
+          <mat-select matInput formControlName="mqttcertfile" (selectionChange)="onChangekMqttConfig()">
+            @for (c of sslFiles; track $index) {
+              <mat-option [value]="c">{{ c }} </mat-option>
+            }
+          </mat-select>
+          <mat-hint>Example: {{ defaultCertFile }}</mat-hint>
+        </mat-form-field>
+        <mat-form-field class="width250pt">
+          <mat-label>Client key file (located in ssl directory)</mat-label>
           <mat-select matInput formControlName="mqttkeyfile" (selectionChange)="onChangekMqttConfig()">
             @for (c of sslFiles; track $index) {
               <mat-option [value]="c">{{ c }} </mat-option>
             }
           </mat-select>
+          <mat-hint>Example: {{ defaultKeyFile }}</mat-hint>
         </mat-form-field>
         <mat-form-field class="width250pt">
           <mat-label>language</mat-label>

--- a/frontend/src/app/configure/configure.component.ts
+++ b/frontend/src/app/configure/configure.component.ts
@@ -18,12 +18,17 @@ import { MatOption } from '@angular/material/core'
 import { MatSelect } from '@angular/material/select'
 import { NgClass } from '@angular/common';
 import { MatInput } from '@angular/material/input'
-import { MatFormField, MatLabel, MatError } from '@angular/material/form-field'
+import { MatFormField, MatLabel, MatError, MatHint } from '@angular/material/form-field'
 import { MatStepLabel } from '@angular/material/stepper'
 import { MatIcon } from '@angular/material/icon'
 import { MatTooltip } from '@angular/material/tooltip'
 import { MatIconButton } from '@angular/material/button'
 import { MatCard, MatCardHeader, MatCardTitle, MatCardContent } from '@angular/material/card'
+
+// Let's Encrypt convention (also used by Home Assistant)
+const DEFAULT_CA_FILE = 'chain.pem'
+const DEFAULT_CERT_FILE = 'cert.pem'
+const DEFAULT_KEY_FILE = 'privkey.pem'
 
 @Component({
   selector: 'app-configure',
@@ -44,6 +49,7 @@ import { MatCard, MatCardHeader, MatCardTitle, MatCardContent } from '@angular/m
     MatLabel,
     MatInput,
     MatError,
+    MatHint,
     MatSelect,
     MatOption,
     NgClass
@@ -53,6 +59,9 @@ import { MatCard, MatCardHeader, MatCardTitle, MatCardContent } from '@angular/m
 export class ConfigureComponent implements OnInit {
   config: Iconfiguration | undefined = undefined
   @Output() isMqttConfiguredEvent = new EventEmitter<boolean>()
+  readonly defaultCaFile = DEFAULT_CA_FILE
+  readonly defaultCertFile = DEFAULT_CERT_FILE
+  readonly defaultKeyFile = DEFAULT_KEY_FILE
 
   constructor(
     private _formBuilder: FormBuilder,
@@ -67,8 +76,9 @@ export class ConfigureComponent implements OnInit {
       mqttserverurl: [null as string | null, this.requiredInNonAddonScenario],
       mqttuser: [null as string | null],
       mqttpassword: [null as string | null],
-      mqttkeyfile: [null as string | null],
       mqttcafile: [null as string | null],
+      mqttcertfile: [null as string | null],
+      mqttkeyfile: [null as string | null],
     })
   }
   private requiredInNonAddonScenario: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
@@ -114,12 +124,22 @@ export class ConfigureComponent implements OnInit {
       if (config.mqttdiscoverylanguage) {
         this.discoveryLanguageFormControl!.setValue(config.mqttdiscoverylanguage)
       }
+      if (config.mqttcaFile) {
+        this.configureMqttFormGroup.get('mqttcafile')!.setValue(config.mqttcaFile)
+      }
+      if (config.mqttcertFile) {
+        this.configureMqttFormGroup.get('mqttcertfile')!.setValue(config.mqttcertFile)
+      }
+      if (config.mqttkeyFile) {
+        this.configureMqttFormGroup.get('mqttkeyfile')!.setValue(config.mqttkeyFile)
+      }
       if (config.debugComponents) {
         this.debugComponentsFormControl!.setValue(config.debugComponents)
       }
 
       this.entityApiService.getSslFiles().subscribe((rc) => {
         this.sslFiles = rc
+        this.applyMtlsDefaultsIfAllPresent(config)
       })
       this.entityApiService.getUserAuthenticationStatus().subscribe((authStatus) => {
         this.authStatus = authStatus
@@ -132,8 +152,9 @@ export class ConfigureComponent implements OnInit {
     const mqttserverurl = form.get('mqttserverurl')
     const mqttuser = form.get('mqttuser')
     const mqttpassword = form.get('mqttpassword')
-    const mqttkeyfile = form.get('mqttkeyfile')
     const mqttcafile = form.get('mqttcafile')
+    const mqttcertfile = form.get('mqttcertfile')
+    const mqttkeyfile = form.get('mqttkeyfile')
     // Save changes to Config and Device
     if (config && mqttserverurl && mqttuser && mqttpassword && mqttserverurl.value) {
       {
@@ -144,12 +165,28 @@ export class ConfigureComponent implements OnInit {
         if (this.discoveryLanguageFormControl && this.discoveryLanguageFormControl.value!)
           config.mqttdiscoverylanguage = this.discoveryLanguageFormControl.value!
         if (mqttcafile) config.mqttcaFile = mqttcafile.value ? mqttcafile.value : undefined
-        else this.config && delete this.config.mqttcaFile
-        if (mqttkeyfile) config.mqttcertFile = mqttkeyfile.value ? mqttkeyfile.value : undefined
-        else config && delete config.mqttcertFile
+        else delete config.mqttcaFile
+        if (mqttcertfile) config.mqttcertFile = mqttcertfile.value ? mqttcertfile.value : undefined
+        else delete config.mqttcertFile
+        if (mqttkeyfile) config.mqttkeyFile = mqttkeyfile.value ? mqttkeyfile.value : undefined
+        else delete config.mqttkeyFile
         if (config.debugComponents) config.debugComponents = this.debugComponentsFormControl!.value
       }
     }
+  }
+
+  private applyMtlsDefaultsIfAllPresent(config: Iconfiguration) {
+    const allPresent =
+      this.sslFiles.includes(DEFAULT_CA_FILE) &&
+      this.sslFiles.includes(DEFAULT_CERT_FILE) &&
+      this.sslFiles.includes(DEFAULT_KEY_FILE)
+    if (!allPresent) return
+    const ca = this.configureMqttFormGroup.get('mqttcafile')
+    const cert = this.configureMqttFormGroup.get('mqttcertfile')
+    const key = this.configureMqttFormGroup.get('mqttkeyfile')
+    if (ca && !ca.value && !config.mqttcaFile) ca.setValue(DEFAULT_CA_FILE)
+    if (cert && !cert.value && !config.mqttcertFile) cert.setValue(DEFAULT_CERT_FILE)
+    if (key && !key.value && !config.mqttkeyFile) key.setValue(DEFAULT_KEY_FILE)
   }
 
   onChangekMqttConfig() {

--- a/modbus2mqtt.code-workspace
+++ b/modbus2mqtt.code-workspace
@@ -109,7 +109,7 @@
         "preLaunchTask": "build modbus2mqtt",
         "timeout": 10000,
         "program": "${workspaceFolder:modbus2mqtt}/dist/server/modbus2mqtt.js",
-        "args": ["-s", "ssl", "-c", "../config-dir", "-d", "../data-dir"],
+        "args": ["-s", "certs", "-c", "../config-dir", "-d", "../data-dir"],
         "console": "integratedTerminal",
         "cwd": "${workspaceFolder:modbus2mqtt}",
         "env": { "DEBUG": "" },


### PR DESCRIPTION
This pull request improves the configuration experience for MQTT mutual TLS (mTLS) by clarifying certificate file selection in the frontend, providing better defaults, and making the MQTT connection validation more robust. It also updates development and launch configurations to use a consistent `certs` directory for SSL files.

**Frontend improvements for mTLS configuration:**

- Updated the MQTT configuration form to clearly separate and label CA certificate, client certificate, and client key fields, including example hints for each and aligning terminology with common conventions (e.g., Let's Encrypt/Home Assistant). [[1]](diffhunk://#diff-24be2050cb3ca53d0b43efc1a9807b9f590ebce4410634ac0f5e9466723fa981L59-R83) [[2]](diffhunk://#diff-a7ab88c29dae285032938aeb49b3104a77321b8301c93b5e1eac4408ac5d2e4aL21-R32) [[3]](diffhunk://#diff-a7ab88c29dae285032938aeb49b3104a77321b8301c93b5e1eac4408ac5d2e4aR52) [[4]](diffhunk://#diff-a7ab88c29dae285032938aeb49b3104a77321b8301c93b5e1eac4408ac5d2e4aR62-R64) [[5]](diffhunk://#diff-a7ab88c29dae285032938aeb49b3104a77321b8301c93b5e1eac4408ac5d2e4aL70-R81)
- Added logic to automatically pre-fill certificate fields with default filenames (`chain.pem`, `cert.pem`, `privkey.pem`) if all are present in the SSL directory, reducing user setup friction. [[1]](diffhunk://#diff-a7ab88c29dae285032938aeb49b3104a77321b8301c93b5e1eac4408ac5d2e4aR127-R142) [[2]](diffhunk://#diff-a7ab88c29dae285032938aeb49b3104a77321b8301c93b5e1eac4408ac5d2e4aL135-R157) [[3]](diffhunk://#diff-a7ab88c29dae285032938aeb49b3104a77321b8301c93b5e1eac4408ac5d2e4aL147-R191)

**Backend improvement for MQTT connection validation:**

- Enhanced the MQTT connection validation method to use a connection timeout and prevent reconnection attempts, ensuring timely and reliable feedback in the UI.

**Development and launch configuration updates:**

- Standardized the SSL directory argument in all launch and workspace configurations from `ssl` to `certs` for consistency across development environments. (.vscode/launch.json, [[1]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L55-R55) [[2]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L89-R89); modbus2mqtt.code-workspace, [[3]](diffhunk://#diff-838687909af250d368273e5db13a8e71ddc56d4b41de875422ef20d6263f928aL112-R112)