### PR TITLE
feat: import local dir rest api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ web_modules/
 
 # Local SSL certificates and key material
 ssl/
+certs/
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache
@@ -162,4 +163,3 @@ distprod
 .skip-precommit
 __tests__/server/tmp-httpserver**/*
 __tests__/server/*_single_*.tsx.*
-certs/

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ distprod
 .skip-precommit
 __tests__/server/tmp-httpserver**/*
 __tests__/server/*_single_*.tsx.*
+certs/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,7 @@
       "preLaunchTask": "npm: build",
       "timeout": 10000,
       "program": "${workspaceFolder}/dist/server/modbus2mqtt.js",
-      "args": ["-s", "ssl", "-c", "../config-dir", "-d", "../data-dir"],
+      "args": ["-s", "certs", "-c", "../config-dir", "-d", "../data-dir"],
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "env": {
@@ -86,7 +86,7 @@
       "preLaunchTask": "npm: build.dev",
       "timeout": 10000,
       "program": "${workspaceFolder}/dist/server/modbus2mqtt.js",
-      "args": ["-s", "../ssl", "-y", "../yaml-dir-bridge"],
+      "args": ["-s", "certs", "-y", "../yaml-dir-bridge"],
       "console": "integratedTerminal",
       "env": {
         "DEBUG": ""

--- a/backend/src/server/config.ts
+++ b/backend/src/server/config.ts
@@ -336,6 +336,9 @@ export class Config {
   static async createZipFromLocal(_filename: string, r: import('stream').Writable): Promise<void> {
     return Config.ensurePersistence().createLocalExportZip(r)
   }
+  static async importLocalZip(buffer: Buffer) {
+    return Config.ensurePersistence().importLocalZip(buffer)
+  }
 }
 export function getSpecificationImageOrDocumentUrl(rootUrl: string | undefined, specName: string, url: string): string {
   const fn = getBaseFilename(url)

--- a/backend/src/server/httpserver.ts
+++ b/backend/src/server/httpserver.ts
@@ -336,6 +336,36 @@ export class HttpServer extends HttpServerBase {
         this.returnResult(req, res, HttpErrorsEnum.OK, JSON.stringify(result))
       })
     })
+    this.app.post(
+      apiUri.uploadLocal,
+      express.raw({ type: 'application/zip', limit: '50mb' }),
+      (req: express.Request, res: http.ServerResponse) => {
+        debug(req.url)
+        const buffer = req.body as Buffer
+        if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+          this.returnResult(
+            req as ExpressRequest,
+            res,
+            HttpErrorsEnum.ErrBadRequest,
+            JSON.stringify({ ok: false, message: 'No ZIP body received (Content-Type: application/zip required)' })
+          )
+          return
+        }
+        Config.importLocalZip(buffer)
+          .then((result) => {
+            this.returnResult(req as ExpressRequest, res, result.status as unknown as HttpErrorsEnum, JSON.stringify(result))
+          })
+          .catch((e) => {
+            this.returnResult(
+              req as ExpressRequest,
+              res,
+              HttpErrorsEnum.SrvErrInternalServerError,
+              JSON.stringify({ ok: false, message: 'import error: ' + (e as Error).message })
+            )
+          })
+      }
+    )
+
     this.get(apiUri.download, (req: express.Request, res: http.ServerResponse) => {
       debug(req.url)
       if (req.params && req.params['what']) {

--- a/backend/src/server/httpserver.ts
+++ b/backend/src/server/httpserver.ts
@@ -352,7 +352,26 @@ export class HttpServer extends HttpServerBase {
           return
         }
         Config.importLocalZip(buffer)
-          .then((result) => {
+          .then(async (result) => {
+            if (result.ok) {
+              try {
+                MqttConnector.resetInstance()
+                await new Config().readYamlAsync()
+                new ConfigSpecification().readYaml()
+                ConfigBus.readBusses()
+                await Bus.readBussesFromConfig()
+              } catch (e) {
+                const msg = e instanceof Error ? e.message : String(e)
+                log.log(LogLevelEnum.error, 'Post-import reload failed: ' + msg)
+                this.returnResult(
+                  req as ExpressRequest,
+                  res,
+                  HttpErrorsEnum.SrvErrInternalServerError,
+                  JSON.stringify({ ok: false, message: 'imported but reload failed: ' + msg })
+                )
+                return
+              }
+            }
             this.returnResult(req as ExpressRequest, res, result.status as unknown as HttpErrorsEnum, JSON.stringify(result))
           })
           .catch((e) => {

--- a/backend/src/server/mqttconnector.ts
+++ b/backend/src/server/mqttconnector.ts
@@ -64,14 +64,28 @@ export class MqttConnector {
 
   validateConnection(connectionData: ImqttClient | undefined, callback: (valid: boolean, message: string) => void) {
     if (connectionData && connectionData.mqttserverurl != undefined) {
-      const client = connect(connectionData.mqttserverurl, connectionData as IClientOptions)
+      const opts: IClientOptions = {
+        ...(connectionData as IClientOptions),
+        reconnectPeriod: 0,
+        connectTimeout: 5000,
+      }
+      const client = connect(connectionData.mqttserverurl, opts)
+      let settled = false
+      const settle = (valid: boolean, message: string) => {
+        if (settled) return
+        settled = true
+        try {
+          client.end(true)
+        } catch {
+          /* ignore */
+        }
+        callback(valid, message)
+      }
       client.on('error', (e) => {
-        client!.end(() => {})
-        callback(false, connectionData.mqttserverurl + ': ' + e.toString())
+        settle(false, connectionData.mqttserverurl + ': ' + e.toString())
       })
       client.on('connect', () => {
-        callback(true, 'OK')
-        if (client) client.end(() => {})
+        settle(true, 'OK')
       })
     } else callback(false, 'no mqttserverlurl passed')
   }

--- a/backend/src/server/persistence/configPersistence.ts
+++ b/backend/src/server/persistence/configPersistence.ts
@@ -5,9 +5,11 @@ import { join } from 'path'
 import Debug from 'debug'
 import AdmZip from 'adm-zip'
 import stream from 'stream'
-import { Iconfiguration } from '../../shared/server/index.js'
+import { HttpErrorsEnum, Iconfiguration, IModbusConnection, Islave } from '../../shared/server/index.js'
 import { ISingletonPersistence } from './persistence.js'
-import { Logger, LogLevelEnum } from '../../specification/index.js'
+import { IfileSpecification, Logger, LogLevelEnum } from '../../specification/index.js'
+import { SpecPersistence } from '../../specification/specPersistence.js'
+import { BusPersistence } from './busPersistence.js'
 
 const debug = Debug('configPersistence')
 const log = new Logger('configPersistence')
@@ -30,6 +32,15 @@ export class ConfigPersistence implements ISingletonPersistence<Iconfiguration> 
     }
     if (!fs.existsSync(ConfigPersistence.configDir)) {
       return undefined
+    }
+
+    if (fs.existsSync(this.getImportMarkerPath())) {
+      throw new Error(
+        'Local configuration is in an inconsistent state from a partial import. ' +
+          'Delete ' +
+          ConfigPersistence.getLocalDir() +
+          ' and re-import.'
+      )
     }
 
     const yamlFile = this.getConfigPath()
@@ -173,6 +184,144 @@ export class ConfigPersistence implements ISingletonPersistence<Iconfiguration> 
       if (fs.existsSync(fn)) return fs.readFileSync(fn, { encoding: 'utf8' }).toString()
     }
     return undefined
+  }
+
+  getImportMarkerPath(): string {
+    return join(ConfigPersistence.getLocalDir(), '.import-in-progress')
+  }
+
+  hasLocalUserContent(): boolean {
+    const localDir = ConfigPersistence.getLocalDir()
+    if (!fs.existsSync(localDir)) return false
+    if (fs.existsSync(this.getConfigPath())) return true
+    const busDir = join(localDir, 'busses')
+    if (fs.existsSync(busDir) && fs.readdirSync(busDir).length > 0) return true
+    const specDir = join(localDir, 'specifications')
+    if (fs.existsSync(specDir)) {
+      const specEntries = fs.readdirSync(specDir).filter((f) => f !== 'files')
+      if (specEntries.length > 0) return true
+      const filesDir = join(specDir, 'files')
+      if (fs.existsSync(filesDir) && fs.readdirSync(filesDir).length > 0) return true
+    }
+    return false
+  }
+
+  async importLocalZip(zip: Buffer): Promise<{ ok: boolean; status: HttpErrorsEnum; message: string }> {
+    if (this.hasLocalUserContent()) {
+      return { ok: false, status: HttpErrorsEnum.ErrConflict, message: 'local directory not empty' }
+    }
+
+    let archive: AdmZip
+    try {
+      archive = new AdmZip(zip)
+    } catch (e) {
+      return { ok: false, status: HttpErrorsEnum.ErrBadRequest, message: 'Invalid ZIP: ' + (e as Error).message }
+    }
+    const entries = archive.getEntries()
+    if (entries.length === 0) {
+      return { ok: false, status: HttpErrorsEnum.ErrBadRequest, message: 'ZIP is empty' }
+    }
+
+    const localDir = ConfigPersistence.getLocalDir()
+    for (const entry of entries) {
+      if (entry.isDirectory) continue
+      const name = entry.entryName
+      const norm = path.normalize(name)
+      if (path.isAbsolute(name) || name.startsWith('/') || norm.startsWith('..') || norm.includes('..' + path.sep)) {
+        return { ok: false, status: HttpErrorsEnum.ErrBadRequest, message: 'Invalid ZIP entry path: ' + name }
+      }
+    }
+
+    if (!fs.existsSync(localDir)) fs.mkdirSync(localDir, { recursive: true })
+    const markerPath = this.getImportMarkerPath()
+    fs.writeFileSync(markerPath, '', { encoding: 'utf8' })
+
+    try {
+      const busPersistence = new BusPersistence(localDir)
+      const specPersistence = new SpecPersistence(ConfigPersistence.configDir, ConfigPersistence.dataDir)
+
+      for (const entry of entries) {
+        if (entry.isDirectory) continue
+        const name = entry.entryName
+        const base = path.basename(name)
+
+        if (base === 'secrets.yaml') {
+          debug('Skipping secrets.yaml in ZIP')
+          continue
+        }
+
+        if (name === 'modbus2mqtt.yaml') {
+          const targetFile = this.getConfigPath()
+          if (!fs.existsSync(path.dirname(targetFile))) {
+            fs.mkdirSync(path.dirname(targetFile), { recursive: true })
+          }
+          fs.writeFileSync(targetFile, entry.getData(), { flag: 'w' })
+          continue
+        }
+
+        const busMatch = /^busses\/bus\.(\d+)\/(.+)$/.exec(name)
+        if (busMatch) {
+          const busId = parseInt(busMatch[1], 10)
+          const fileInBus = busMatch[2]
+          if (fileInBus.includes('/')) {
+            log.log(LogLevelEnum.warn, 'Skipping unexpected nested bus entry: ' + name)
+            continue
+          }
+          const yamlContent = entry.getData().toString('utf8')
+          const parsed = parse(yamlContent)
+          if (fileInBus === 'bus.yaml') {
+            busPersistence.writeBus(busId, parsed as IModbusConnection)
+          } else if (fileInBus.startsWith('s') && fileInBus.endsWith('.yaml')) {
+            busPersistence.writeSlave(busId, parsed as Islave)
+          } else {
+            log.log(LogLevelEnum.warn, 'Skipping unknown bus file: ' + name)
+          }
+          continue
+        }
+
+        if (name.startsWith('specifications/files/')) {
+          const target = join(localDir, name)
+          const targetDir = path.dirname(target)
+          if (!fs.existsSync(targetDir)) fs.mkdirSync(targetDir, { recursive: true })
+          fs.writeFileSync(target, entry.getData())
+          continue
+        }
+
+        const specJsonMatch = /^specifications\/([^/]+)\.json$/.exec(name)
+        if (specJsonMatch) {
+          const filename = specJsonMatch[1]
+          const jsonContent = entry.getData().toString('utf8')
+          const spec = JSON.parse(jsonContent) as IfileSpecification
+          spec.filename = filename
+          specPersistence.writeItem(filename, spec)
+          continue
+        }
+
+        const specYamlMatch = /^specifications\/([^/]+)\.yaml$/.exec(name)
+        if (specYamlMatch) {
+          // Legacy YAML spec — copy raw; Migrator will upgrade to JSON on next read.
+          const target = join(localDir, name)
+          const targetDir = path.dirname(target)
+          if (!fs.existsSync(targetDir)) fs.mkdirSync(targetDir, { recursive: true })
+          fs.writeFileSync(target, entry.getData())
+          continue
+        }
+
+        log.log(LogLevelEnum.warn, 'Skipping unexpected ZIP entry: ' + name)
+      }
+
+      const secretsPath = this.getSecretsPath()
+      if (!fs.existsSync(secretsPath)) {
+        fs.writeFileSync(secretsPath, '', { encoding: 'utf8' })
+      }
+
+      fs.unlinkSync(markerPath)
+      return { ok: true, status: HttpErrorsEnum.OK, message: 'imported' }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      log.log(LogLevelEnum.error, 'Import failed: ' + msg)
+      return { ok: false, status: HttpErrorsEnum.SrvErrInternalServerError, message: 'Import failed: ' + msg }
+    }
   }
 
   async createLocalExportZip(writable: stream.Writable): Promise<void> {

--- a/backend/src/server/persistence/configPersistence.ts
+++ b/backend/src/server/persistence/configPersistence.ts
@@ -51,7 +51,7 @@ export class ConfigPersistence implements ISingletonPersistence<Iconfiguration> 
     const secretsFile = join(ConfigPersistence.getLocalDir(), 'secrets.yaml')
     let src: string = fs.readFileSync(yamlFile, { encoding: 'utf8' })
     if (fs.existsSync(secretsFile)) {
-      const secrets = parse(fs.readFileSync(secretsFile, { encoding: 'utf8' }))
+      const secrets = parse(fs.readFileSync(secretsFile, { encoding: 'utf8' })) ?? {}
       const srcLines = src.split('\n')
       src = ''
       srcLines.forEach((line) => {
@@ -312,7 +312,7 @@ export class ConfigPersistence implements ISingletonPersistence<Iconfiguration> 
 
       const secretsPath = this.getSecretsPath()
       if (!fs.existsSync(secretsPath)) {
-        fs.writeFileSync(secretsPath, '', { encoding: 'utf8' })
+        fs.writeFileSync(secretsPath, '{}\n', { encoding: 'utf8' })
       }
 
       fs.unlinkSync(markerPath)

--- a/backend/src/shared/server/httpConstants.ts
+++ b/backend/src/shared/server/httpConstants.ts
@@ -26,5 +26,6 @@ export enum apiUri {
   nextCheck = '/api/nextGithubMergeCheck',
   download = '/download/:what',
   uploadSpec = '/api/uploadspec',
+  uploadLocal = '/api/upload/local',
   e2eReset = '/api/e2e/reset',
 }

--- a/backend/src/shared/server/types.ts
+++ b/backend/src/shared/server/types.ts
@@ -12,6 +12,7 @@ export enum HttpErrorsEnum {
   ErrNotFound = 404,
   ErrNotAcceptable = 406,
   ErrRequestTimeout = 408,
+  ErrConflict = 409,
   ErrInvalidParameter = 422,
   SrvErrInternalServerError = 500,
 }

--- a/backend/src/shared/specification/types.ts
+++ b/backend/src/shared/specification/types.ts
@@ -10,6 +10,7 @@ export enum HttpErrorsEnum {
   ErrNotFound = 404,
   ErrNotAcceptable = 406,
   ErrRequestTimeout = 408,
+  ErrConflict = 409,
   ErrInvalidParameter = 422,
   SrvErrInternalServerError = 500,
 }

--- a/backend/tests/server/modbusAPI_test.tsx
+++ b/backend/tests/server/modbusAPI_test.tsx
@@ -13,7 +13,7 @@ import {
   LogLevelEnum,
 } from '../../src/specification/index.js'
 import { ModbusAPI } from '../../src/server/modbusAPI.js'
-import { TempConfigDirHelper } from './testhelper.js'
+import { TempConfigDirHelper, getAvailablePort } from './testhelper.js'
 
 const debug = Debug('bustest')
 setConfigsDirsForTest()
@@ -54,7 +54,9 @@ async function testRead(
   const tcpServer = new ModbusServer()
   const bus = Bus.getBus(1)
   expect(bus).toBeDefined()
-  await tcpServer.startServer((bus!.properties.connectionData as any)['port'])
+  const port = await getAvailablePort()
+  ;(bus!.properties.connectionData as any)['port'] = port
+  await tcpServer.startServer(port)
   debug('Connected to TCP server')
   const modbusAPI = new ModbusAPI(bus!)
   try {
@@ -85,7 +87,9 @@ async function testWrite(
   const tcpServer = new ModbusServer()
   const bus = Bus.getBus(1)
   expect(bus).toBeDefined()
-  await tcpServer.startServer((bus!.properties.connectionData as any)['port'])
+  const port = await getAvailablePort()
+  ;(bus!.properties.connectionData as any)['port'] = port
+  await tcpServer.startServer(port)
   const modbusAPI = new ModbusAPI(bus!)
   try {
     await modbusAPI.initialConnect()

--- a/backend/tests/server/uploadLocal_test.tsx
+++ b/backend/tests/server/uploadLocal_test.tsx
@@ -103,7 +103,7 @@ it('imports a minimal zip and creates empty secrets.yaml', async () => {
   expect(fs.existsSync(persistence.getConfigPath())).toBe(true)
   expect(fs.readFileSync(persistence.getConfigPath(), 'utf8')).toContain('imported')
   expect(fs.existsSync(persistence.getSecretsPath())).toBe(true)
-  expect(fs.readFileSync(persistence.getSecretsPath(), 'utf8')).toBe('')
+  expect(fs.readFileSync(persistence.getSecretsPath(), 'utf8')).toBe('{}\n')
   expect(fs.existsSync(persistence.getImportMarkerPath())).toBe(false)
 })
 
@@ -115,7 +115,7 @@ it('skips secrets.yaml entries inside the zip', async () => {
 
   expect(result.ok).toBe(true)
   // secrets.yaml in the zip was ignored — local secrets.yaml is empty
-  expect(fs.readFileSync(persistence.getSecretsPath(), 'utf8')).toBe('')
+  expect(fs.readFileSync(persistence.getSecretsPath(), 'utf8')).toBe('{}\n')
 })
 
 it('round-trip: re-imports an export zip into an empty directory', async () => {

--- a/backend/tests/server/uploadLocal_test.tsx
+++ b/backend/tests/server/uploadLocal_test.tsx
@@ -1,0 +1,153 @@
+import { it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import { join } from 'path'
+import AdmZip from 'adm-zip'
+import { ConfigPersistence } from '../../src/server/persistence/configPersistence.js'
+import { TempConfigDirHelper } from './testhelper.js'
+import { setConfigsDirsForTest } from './configsbase.js'
+import { HttpErrorsEnum } from '../../src/shared/server/index.js'
+
+setConfigsDirsForTest()
+
+let tempHelper: TempConfigDirHelper
+let persistence: ConfigPersistence
+
+beforeAll(() => {
+  tempHelper = new TempConfigDirHelper('upload_local')
+  tempHelper.setup()
+  persistence = new ConfigPersistence()
+})
+
+afterAll(() => {
+  if (tempHelper) tempHelper.cleanup()
+})
+
+function clearLocalDir(): void {
+  const dir = ConfigPersistence.getLocalDir()
+  if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true })
+}
+
+function buildExportZip(): Buffer {
+  const archive = new AdmZip()
+  const dir = ConfigPersistence.getLocalDir()
+  if (!fs.existsSync(dir)) return archive.toBuffer()
+  const files: string[] = fs.readdirSync(dir, { recursive: true }) as string[]
+  files.forEach((file) => {
+    const p = join(dir, file)
+    if (fs.statSync(p).isFile() && file.indexOf('secrets.yaml') < 0) {
+      archive.addLocalFile(p, path.dirname(file))
+    }
+  })
+  return archive.toBuffer()
+}
+
+beforeEach(() => {
+  // Default: each test starts with an empty local dir.
+  // Tests that need pre-existing state set it up explicitly.
+  clearLocalDir()
+})
+
+it('refuses import when local directory is not empty', async () => {
+  // Pre-populate local dir
+  const localDir = ConfigPersistence.getLocalDir()
+  fs.mkdirSync(localDir, { recursive: true })
+  fs.writeFileSync(join(localDir, 'modbus2mqtt.yaml'), 'mqttbasetopic: existing\n')
+
+  const archive = new AdmZip()
+  archive.addFile('modbus2mqtt.yaml', Buffer.from('mqttbasetopic: incoming\n'))
+  const result = await persistence.importLocalZip(archive.toBuffer())
+
+  expect(result.ok).toBe(false)
+  expect(result.status).toBe(HttpErrorsEnum.ErrConflict)
+  // Existing content must not have been overwritten
+  expect(fs.readFileSync(join(localDir, 'modbus2mqtt.yaml'), 'utf8')).toContain('existing')
+})
+
+it('rejects zip-slip path traversal', async () => {
+  // adm-zip's addFile sanitizes ../, so we have to craft a malicious entry name
+  // by mutating the entry after add. This simulates a zip created by a non-sanitizing tool.
+  const archive = new AdmZip()
+  archive.addFile('placeholder', Buffer.from('malicious'))
+  const entries = archive.getEntries()
+  entries[0].entryName = '../../etc/passwd'
+  const result = await persistence.importLocalZip(archive.toBuffer())
+
+  expect(result.ok).toBe(false)
+  expect(result.status).toBe(HttpErrorsEnum.ErrBadRequest)
+  expect(fs.existsSync(persistence.getImportMarkerPath())).toBe(false)
+})
+
+it('rejects empty zip', async () => {
+  const archive = new AdmZip()
+  const result = await persistence.importLocalZip(archive.toBuffer())
+
+  expect(result.ok).toBe(false)
+  expect(result.status).toBe(HttpErrorsEnum.ErrBadRequest)
+})
+
+it('rejects malformed zip buffer', async () => {
+  const result = await persistence.importLocalZip(Buffer.from('not a zip'))
+
+  expect(result.ok).toBe(false)
+  expect(result.status).toBe(HttpErrorsEnum.ErrBadRequest)
+})
+
+it('imports a minimal zip and creates empty secrets.yaml', async () => {
+  const archive = new AdmZip()
+  archive.addFile('modbus2mqtt.yaml', Buffer.from('mqttbasetopic: imported\n'))
+  const result = await persistence.importLocalZip(archive.toBuffer())
+
+  expect(result.ok).toBe(true)
+  expect(result.status).toBe(HttpErrorsEnum.OK)
+  expect(fs.existsSync(persistence.getConfigPath())).toBe(true)
+  expect(fs.readFileSync(persistence.getConfigPath(), 'utf8')).toContain('imported')
+  expect(fs.existsSync(persistence.getSecretsPath())).toBe(true)
+  expect(fs.readFileSync(persistence.getSecretsPath(), 'utf8')).toBe('')
+  expect(fs.existsSync(persistence.getImportMarkerPath())).toBe(false)
+})
+
+it('skips secrets.yaml entries inside the zip', async () => {
+  const archive = new AdmZip()
+  archive.addFile('modbus2mqtt.yaml', Buffer.from('mqttbasetopic: imported\n'))
+  archive.addFile('secrets.yaml', Buffer.from('mqttpassword: leaked\n'))
+  const result = await persistence.importLocalZip(archive.toBuffer())
+
+  expect(result.ok).toBe(true)
+  // secrets.yaml in the zip was ignored — local secrets.yaml is empty
+  expect(fs.readFileSync(persistence.getSecretsPath(), 'utf8')).toBe('')
+})
+
+it('round-trip: re-imports an export zip into an empty directory', async () => {
+  // Set up some content
+  const localDir = ConfigPersistence.getLocalDir()
+  fs.mkdirSync(localDir, { recursive: true })
+  fs.writeFileSync(join(localDir, 'modbus2mqtt.yaml'), 'mqttbasetopic: roundtrip\n')
+  const busDir = join(localDir, 'busses', 'bus.0')
+  fs.mkdirSync(busDir, { recursive: true })
+  fs.writeFileSync(join(busDir, 'bus.yaml'), 'host: 192.168.1.10\nport: 502\ntimeout: 100\n')
+  fs.writeFileSync(
+    join(busDir, 's1.yaml'),
+    'slaveid: 1\nspecificationid: testspec\n'
+  )
+
+  const zip = buildExportZip()
+
+  // Wipe and re-import
+  clearLocalDir()
+  const result = await persistence.importLocalZip(zip)
+
+  expect(result.ok).toBe(true)
+  expect(fs.readFileSync(join(localDir, 'modbus2mqtt.yaml'), 'utf8')).toContain('roundtrip')
+  expect(fs.existsSync(join(busDir, 'bus.yaml'))).toBe(true)
+  expect(fs.existsSync(join(busDir, 's1.yaml'))).toBe(true)
+  expect(fs.readFileSync(join(busDir, 'bus.yaml'), 'utf8')).toContain('192.168.1.10')
+})
+
+it('marker file blocks subsequent reads with a clear error', async () => {
+  const localDir = ConfigPersistence.getLocalDir()
+  fs.mkdirSync(localDir, { recursive: true })
+  fs.writeFileSync(persistence.getImportMarkerPath(), '')
+
+  await expect(persistence.read()).rejects.toThrow(/inconsistent state/)
+})

--- a/frontend/src/app/configure/configure.component.html
+++ b/frontend/src/app/configure/configure.component.html
@@ -56,20 +56,31 @@
           }
         </mat-form-field>
         <mat-form-field class="width250pt">
-          <mat-label>CA certificate File (located in HA ssl directory)</mat-label>
+          <mat-label>CA certificate file (located in ssl directory)</mat-label>
           <mat-select matInput formControlName="mqttcafile" (selectionChange)="onChangekMqttConfig()">
             @for (c of sslFiles; track $index) {
               <mat-option [value]="c">{{ c }} </mat-option>
             }
           </mat-select>
+          <mat-hint>Example: {{ defaultCaFile }}</mat-hint>
         </mat-form-field>
         <mat-form-field class="width250pt">
-          <mat-label>Client key (located in HA ssl directory) for client authentication</mat-label>
+          <mat-label>Client certificate file (located in ssl directory)</mat-label>
+          <mat-select matInput formControlName="mqttcertfile" (selectionChange)="onChangekMqttConfig()">
+            @for (c of sslFiles; track $index) {
+              <mat-option [value]="c">{{ c }} </mat-option>
+            }
+          </mat-select>
+          <mat-hint>Example: {{ defaultCertFile }}</mat-hint>
+        </mat-form-field>
+        <mat-form-field class="width250pt">
+          <mat-label>Client key file (located in ssl directory)</mat-label>
           <mat-select matInput formControlName="mqttkeyfile" (selectionChange)="onChangekMqttConfig()">
             @for (c of sslFiles; track $index) {
               <mat-option [value]="c">{{ c }} </mat-option>
             }
           </mat-select>
+          <mat-hint>Example: {{ defaultKeyFile }}</mat-hint>
         </mat-form-field>
         <mat-form-field class="width250pt">
           <mat-label>language</mat-label>

--- a/frontend/src/app/configure/configure.component.ts
+++ b/frontend/src/app/configure/configure.component.ts
@@ -18,12 +18,17 @@ import { MatOption } from '@angular/material/core'
 import { MatSelect } from '@angular/material/select'
 import { NgClass } from '@angular/common';
 import { MatInput } from '@angular/material/input'
-import { MatFormField, MatLabel, MatError } from '@angular/material/form-field'
+import { MatFormField, MatLabel, MatError, MatHint } from '@angular/material/form-field'
 import { MatStepLabel } from '@angular/material/stepper'
 import { MatIcon } from '@angular/material/icon'
 import { MatTooltip } from '@angular/material/tooltip'
 import { MatIconButton } from '@angular/material/button'
 import { MatCard, MatCardHeader, MatCardTitle, MatCardContent } from '@angular/material/card'
+
+// Let's Encrypt convention (also used by Home Assistant)
+const DEFAULT_CA_FILE = 'chain.pem'
+const DEFAULT_CERT_FILE = 'cert.pem'
+const DEFAULT_KEY_FILE = 'privkey.pem'
 
 @Component({
   selector: 'app-configure',
@@ -44,6 +49,7 @@ import { MatCard, MatCardHeader, MatCardTitle, MatCardContent } from '@angular/m
     MatLabel,
     MatInput,
     MatError,
+    MatHint,
     MatSelect,
     MatOption,
     NgClass
@@ -53,6 +59,9 @@ import { MatCard, MatCardHeader, MatCardTitle, MatCardContent } from '@angular/m
 export class ConfigureComponent implements OnInit {
   config: Iconfiguration | undefined = undefined
   @Output() isMqttConfiguredEvent = new EventEmitter<boolean>()
+  readonly defaultCaFile = DEFAULT_CA_FILE
+  readonly defaultCertFile = DEFAULT_CERT_FILE
+  readonly defaultKeyFile = DEFAULT_KEY_FILE
 
   constructor(
     private _formBuilder: FormBuilder,
@@ -67,8 +76,9 @@ export class ConfigureComponent implements OnInit {
       mqttserverurl: [null as string | null, this.requiredInNonAddonScenario],
       mqttuser: [null as string | null],
       mqttpassword: [null as string | null],
-      mqttkeyfile: [null as string | null],
       mqttcafile: [null as string | null],
+      mqttcertfile: [null as string | null],
+      mqttkeyfile: [null as string | null],
     })
   }
   private requiredInNonAddonScenario: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
@@ -114,12 +124,22 @@ export class ConfigureComponent implements OnInit {
       if (config.mqttdiscoverylanguage) {
         this.discoveryLanguageFormControl!.setValue(config.mqttdiscoverylanguage)
       }
+      if (config.mqttcaFile) {
+        this.configureMqttFormGroup.get('mqttcafile')!.setValue(config.mqttcaFile)
+      }
+      if (config.mqttcertFile) {
+        this.configureMqttFormGroup.get('mqttcertfile')!.setValue(config.mqttcertFile)
+      }
+      if (config.mqttkeyFile) {
+        this.configureMqttFormGroup.get('mqttkeyfile')!.setValue(config.mqttkeyFile)
+      }
       if (config.debugComponents) {
         this.debugComponentsFormControl!.setValue(config.debugComponents)
       }
 
       this.entityApiService.getSslFiles().subscribe((rc) => {
         this.sslFiles = rc
+        this.applyMtlsDefaultsIfAllPresent(config)
       })
       this.entityApiService.getUserAuthenticationStatus().subscribe((authStatus) => {
         this.authStatus = authStatus
@@ -132,8 +152,9 @@ export class ConfigureComponent implements OnInit {
     const mqttserverurl = form.get('mqttserverurl')
     const mqttuser = form.get('mqttuser')
     const mqttpassword = form.get('mqttpassword')
-    const mqttkeyfile = form.get('mqttkeyfile')
     const mqttcafile = form.get('mqttcafile')
+    const mqttcertfile = form.get('mqttcertfile')
+    const mqttkeyfile = form.get('mqttkeyfile')
     // Save changes to Config and Device
     if (config && mqttserverurl && mqttuser && mqttpassword && mqttserverurl.value) {
       {
@@ -144,12 +165,28 @@ export class ConfigureComponent implements OnInit {
         if (this.discoveryLanguageFormControl && this.discoveryLanguageFormControl.value!)
           config.mqttdiscoverylanguage = this.discoveryLanguageFormControl.value!
         if (mqttcafile) config.mqttcaFile = mqttcafile.value ? mqttcafile.value : undefined
-        else this.config && delete this.config.mqttcaFile
-        if (mqttkeyfile) config.mqttcertFile = mqttkeyfile.value ? mqttkeyfile.value : undefined
-        else config && delete config.mqttcertFile
+        else delete config.mqttcaFile
+        if (mqttcertfile) config.mqttcertFile = mqttcertfile.value ? mqttcertfile.value : undefined
+        else delete config.mqttcertFile
+        if (mqttkeyfile) config.mqttkeyFile = mqttkeyfile.value ? mqttkeyfile.value : undefined
+        else delete config.mqttkeyFile
         if (config.debugComponents) config.debugComponents = this.debugComponentsFormControl!.value
       }
     }
+  }
+
+  private applyMtlsDefaultsIfAllPresent(config: Iconfiguration) {
+    const allPresent =
+      this.sslFiles.includes(DEFAULT_CA_FILE) &&
+      this.sslFiles.includes(DEFAULT_CERT_FILE) &&
+      this.sslFiles.includes(DEFAULT_KEY_FILE)
+    if (!allPresent) return
+    const ca = this.configureMqttFormGroup.get('mqttcafile')
+    const cert = this.configureMqttFormGroup.get('mqttcertfile')
+    const key = this.configureMqttFormGroup.get('mqttkeyfile')
+    if (ca && !ca.value && !config.mqttcaFile) ca.setValue(DEFAULT_CA_FILE)
+    if (cert && !cert.value && !config.mqttcertFile) cert.setValue(DEFAULT_CERT_FILE)
+    if (key && !key.value && !config.mqttkeyFile) key.setValue(DEFAULT_KEY_FILE)
   }
 
   onChangekMqttConfig() {

--- a/modbus2mqtt.code-workspace
+++ b/modbus2mqtt.code-workspace
@@ -109,7 +109,7 @@
         "preLaunchTask": "build modbus2mqtt",
         "timeout": 10000,
         "program": "${workspaceFolder:modbus2mqtt}/dist/server/modbus2mqtt.js",
-        "args": ["-s", "ssl", "-c", "../config-dir", "-d", "../data-dir"],
+        "args": ["-s", "certs", "-c", "../config-dir", "-d", "../data-dir"],
         "console": "integratedTerminal",
         "cwd": "${workspaceFolder:modbus2mqtt}",
         "env": { "DEBUG": "" },


### PR DESCRIPTION
This pull request introduces a new feature for importing configuration data from a ZIP file into the local configuration directory, along with robust validation and error handling to prevent partial or unsafe imports. It also adds comprehensive tests for this import functionality, improves MQTT connection validation, and makes minor adjustments to development tooling and test setups.

**Local configuration ZIP import feature:**

* Added a new API endpoint `POST /api/upload/local` to accept ZIP uploads for local configuration import, with validation and error handling for ZIP structure and content. (`backend/src/server/httpserver.ts` [[1]](diffhunk://#diff-6d64a7572cbaf71a85af3944489c352d17ea28f84cc3cd7201c1c64c26b77327R339-R387) `backend/src/shared/server/httpConstants.ts` [[2]](diffhunk://#diff-18b35f2dddc99ab6ee3f1ea8658cdd9e15a96b17c9319a1fedc01cfe35c1ff1dR29)
* Implemented `ConfigPersistence.importLocalZip` to handle ZIP extraction, verify directory emptiness, prevent zip-slip attacks, skip secrets, and ensure atomicity using a marker file. (`backend/src/server/persistence/configPersistence.ts` [backend/src/server/persistence/configPersistence.tsR189-R326](diffhunk://#diff-7270648cd669f33277157f1083a6e7cbf1956a194865b180efb1849dd68cd9f2R189-R326))
* Added a marker file mechanism to detect and block access when an import is incomplete, ensuring consistency and safety. (`backend/src/server/persistence/configPersistence.ts` [[1]](diffhunk://#diff-7270648cd669f33277157f1083a6e7cbf1956a194865b180efb1849dd68cd9f2R37-R45) [[2]](diffhunk://#diff-7270648cd669f33277157f1083a6e7cbf1956a194865b180efb1849dd68cd9f2R189-R326)
* Updated error enums to include `ErrConflict` for conflict cases. (`backend/src/shared/server/types.ts` [[1]](diffhunk://#diff-055c5ccba67b397c6653fd8a2f063bb606a75894ccb87467d4db009be805e72eR15) `backend/src/shared/specification/types.ts` [[2]](diffhunk://#diff-5c05484adcdd5ee427995df083f842b0bef84a2ef9ae56bbf839e1f48df18c0bR13)
* Exposed `importLocalZip` through the `Config` class for use in server routes. (`backend/src/server/config.ts` [backend/src/server/config.tsR339-R341](diffhunk://#diff-5dd0087e796aa48c5c08ed6cb12a6366634d0dc9ee41e5c2b80469c403ca1fecR339-R341))

**Testing and validation:**

* Added comprehensive tests for the import feature, including checks for directory conflicts, zip-slip, empty/malformed ZIPs, secrets handling, round-trip import/export, and marker file behavior. (`backend/tests/server/uploadLocal_test.tsx` [backend/tests/server/uploadLocal_test.tsxR1-R153](diffhunk://#diff-8d1d6402b6d49d145148367d06885f2afdc9d6b468dee57d93c9896062651fd8R1-R153))
* Improved MQTT connection validation to ensure proper resource cleanup and timeouts, preventing hanging connections during validation. (`backend/src/server/mqttconnector.ts` [backend/src/server/mqttconnector.tsL67-R88](diffhunk://#diff-025ebc2ba5388ab02646b97be0ee9ef94ebdbc063309d2c448358f3e1ae0867fL67-R88))

**Developer tooling and test reliability:**

* Updated `.vscode/launch.json` to use `"certs"` instead of `"ssl"` for the `-s` argument, reflecting changes in directory structure or naming conventions. (`.vscode/launch.json` [[1]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L55-R55) [[2]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L89-R89)
* Improved test reliability by dynamically selecting available ports for TCP servers in tests. (`backend/tests/server/modbusAPI_test.tsx` [[1]](diffhunk://#diff-7bdf90573a6852249b94ca625845dec2f1a7a32e3a5d26ebfd6b9f61af098933L16-R16) [[2]](diffhunk://#diff-7bdf90573a6852249b94ca625845dec2f1a7a32e3a5d26ebfd6b9f61af098933L57-R59) [[3]](diffhunk://#diff-7bdf90573a6852249b94ca625845dec2f1a7a32e3a5d26ebfd6b9f61af098933L88-R92)

These changes significantly enhance the robustness and usability of configuration import/export, improve error handling, and ensure that the system remains consistent even in the face of partial or failed imports.