### PR TITLE
ci: (release-assets): install backend deps before running tests

### DIFF
--- a/.github/workflows/release-assets-on-dispatch.yml
+++ b/.github/workflows/release-assets-on-dispatch.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Install dependencies and build
         run: |
           pnpm install --frozen-lockfile
+          (cd backend && pnpm install --frozen-lockfile)
           (cd frontend && pnpm install --frozen-lockfile)
           pnpm run build
 


### PR DESCRIPTION
The release-assets-on-dispatch workflow installed dependencies in the root and frontend only, then ran 'cd backend && pnpm run test' which failed with 'sh: 1: vitest: not found' because backend/node_modules was missing. The pnpm 'shamefully-hoist' setting hoists root deps but does not link backend's package.json devDependencies into root, so the backend needs its own install step (matching build-and-test-on-pr.yml).
