### PR TITLE
ci: release assets install backend

### DIFF
--- a/.github/workflows/release-assets-on-dispatch.yml
+++ b/.github/workflows/release-assets-on-dispatch.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Install dependencies and build
         run: |
           pnpm install --frozen-lockfile
+          (cd backend && pnpm install --frozen-lockfile)
           (cd frontend && pnpm install --frozen-lockfile)
           pnpm run build
 

--- a/backend/tests/integration/validate.integration.test.ts
+++ b/backend/tests/integration/validate.integration.test.ts
@@ -16,7 +16,7 @@ import { promisify } from 'util'
 
 const execFile = promisify(execFileCb)
 
-const TEST_REPO = process.env.TEST_CONFIG_REPO
+const TEST_REPO = process.env.TEST_CONFIG_REPO || 'modbus2mqtt/modbus2mqtt.config.test'
 const TEST_RUN_ID = `inttest-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
 /** Minimal valid IfileSpecification for testing */
@@ -82,9 +82,8 @@ describe('JSON spec validation (local, no GitHub needed)', () => {
 })
 
 const hasToken = !!process.env.GITHUB_TOKEN
-const hasTestRepo = !!TEST_REPO
 
-describe.skipIf(!hasToken || !hasTestRepo)('GitHub integration (requires GITHUB_TOKEN and TEST_CONFIG_REPO)', () => {
+describe.skipIf(!hasToken)('GitHub integration (requires GITHUB_TOKEN)', () => {
   let gh: M2mGithubValidate
   const branchName = `test/${TEST_RUN_ID}`
   let prNumber: number | undefined
@@ -92,7 +91,7 @@ describe.skipIf(!hasToken || !hasTestRepo)('GitHub integration (requires GITHUB_
 
   beforeAll(async () => {
 
-    gh = new M2mGithubValidate(TEST_REPO!)
+    gh = new M2mGithubValidate(TEST_REPO)
 
     // 1. Clone test repo into temp dir (with token for push access)
     const tmpDir = fs.mkdtempSync(join(tmpdir(), 'm2m-inttest-'))
@@ -125,7 +124,7 @@ describe.skipIf(!hasToken || !hasTestRepo)('GitHub integration (requires GITHUB_
           'pr',
           'create',
           '--repo',
-          TEST_REPO!,
+          TEST_REPO,
           '--base',
           'main',
           '--head',

--- a/backend/tests/integration/validate.integration.test.ts
+++ b/backend/tests/integration/validate.integration.test.ts
@@ -16,7 +16,7 @@ import { promisify } from 'util'
 
 const execFile = promisify(execFileCb)
 
-const TEST_REPO = process.env.TEST_CONFIG_REPO || 'modbus2mqtt/modbus2mqtt.config.test'
+const TEST_REPO = process.env.TEST_CONFIG_REPO
 const TEST_RUN_ID = `inttest-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
 /** Minimal valid IfileSpecification for testing */
@@ -82,8 +82,9 @@ describe('JSON spec validation (local, no GitHub needed)', () => {
 })
 
 const hasToken = !!process.env.GITHUB_TOKEN
+const hasTestRepo = !!TEST_REPO
 
-describe.skipIf(!hasToken)('GitHub integration (requires GITHUB_TOKEN)', () => {
+describe.skipIf(!hasToken || !hasTestRepo)('GitHub integration (requires GITHUB_TOKEN and TEST_CONFIG_REPO)', () => {
   let gh: M2mGithubValidate
   const branchName = `test/${TEST_RUN_ID}`
   let prNumber: number | undefined
@@ -91,7 +92,7 @@ describe.skipIf(!hasToken)('GitHub integration (requires GITHUB_TOKEN)', () => {
 
   beforeAll(async () => {
 
-    gh = new M2mGithubValidate(TEST_REPO)
+    gh = new M2mGithubValidate(TEST_REPO!)
 
     // 1. Clone test repo into temp dir (with token for push access)
     const tmpDir = fs.mkdtempSync(join(tmpdir(), 'm2m-inttest-'))
@@ -124,7 +125,7 @@ describe.skipIf(!hasToken)('GitHub integration (requires GITHUB_TOKEN)', () => {
           'pr',
           'create',
           '--repo',
-          TEST_REPO,
+          TEST_REPO!,
           '--base',
           'main',
           '--head',


### PR DESCRIPTION
This pull request makes a minor update to the release workflow by ensuring that dependencies are installed in the `backend` directory during the build process. This helps prevent any missing dependency issues for the backend code during releases.

* Updated the release workflow (`.github/workflows/release-assets-on-dispatch.yml`) to run `pnpm install` in the `backend` directory, ensuring backend dependencies are installed before building.