### PR TITLE
feat: implement SSL file listing and reading functionality in ConfigP…

### DIFF
--- a/backend/src/server/httpserver.ts
+++ b/backend/src/server/httpserver.ts
@@ -189,7 +189,7 @@ export class HttpServer extends HttpServerBase {
 
     this.get(apiUri.sslFiles, (req: ExpressRequest, res: http.ServerResponse) => {
       if (ConfigPersistence.sslDir && ConfigPersistence.sslDir.length) {
-        const result = fs.readdirSync(ConfigPersistence.sslDir)
+        const result = new ConfigPersistence().listSslFiles()
         this.returnResult(req, res, HttpErrorsEnum.OK, JSON.stringify(result))
       } else {
         this.returnResult(req, res, HttpErrorsEnum.ErrNotFound, 'not found')

--- a/backend/src/server/persistence/configPersistence.ts
+++ b/backend/src/server/persistence/configPersistence.ts
@@ -181,9 +181,36 @@ export class ConfigPersistence implements ISingletonPersistence<Iconfiguration> 
   readCertificateFile(filename?: string): string | undefined {
     if (filename && ConfigPersistence.sslDir) {
       const fn = join(ConfigPersistence.sslDir, filename)
-      if (fs.existsSync(fn)) return fs.readFileSync(fn, { encoding: 'utf8' }).toString()
+      // Prevent path traversal: the resolved file must stay inside sslDir
+      const base = path.resolve(ConfigPersistence.sslDir)
+      const resolved = path.resolve(fn)
+      if (resolved !== base && !resolved.startsWith(base + path.sep)) {
+        log.log(LogLevelEnum.error, `readCertificateFile: refusing path outside ssl directory: ${filename}`)
+        return undefined
+      }
+      if (fs.existsSync(fn) && fs.statSync(fn).isFile()) return fs.readFileSync(fn, { encoding: 'utf8' }).toString()
     }
     return undefined
+  }
+
+  /**
+   * Recursively lists all certificate files in the ssl directory.
+   * Returns paths relative to sslDir using forward slashes (e.g. "mtls/client.pem"),
+   * so certificates stored in subdirectories can be selected in the UI.
+   */
+  listSslFiles(): string[] {
+    if (!ConfigPersistence.sslDir || !ConfigPersistence.sslDir.length) return []
+    const root = ConfigPersistence.sslDir
+    const result: string[] = []
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name)
+        if (entry.isDirectory()) walk(full)
+        else if (entry.isFile()) result.push(path.relative(root, full).split(path.sep).join('/'))
+      }
+    }
+    walk(root)
+    return result
   }
 
   getImportMarkerPath(): string {

--- a/backend/tests/server/backendTCP/config-dir/modbus2mqtt/busses/bus.0/bus.yaml
+++ b/backend/tests/server/backendTCP/config-dir/modbus2mqtt/busses/bus.0/bus.yaml
@@ -1,3 +1,3 @@
 host: localhost
-port: 3010
+port: 18502
 timeout: 200

--- a/backend/tests/server/config_sslfiles_test.tsx
+++ b/backend/tests/server/config_sslfiles_test.tsx
@@ -1,0 +1,77 @@
+import { expect, it, describe, beforeAll, afterAll } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import { join } from 'path'
+import { ConfigPersistence } from '../../src/server/persistence/configPersistence.js'
+
+let tempSslDir: string
+let originalSslDir: string
+
+beforeAll(() => {
+  originalSslDir = ConfigPersistence.sslDir
+  tempSslDir = fs.mkdtempSync(join(os.tmpdir(), 'sslfiles-test-'))
+  // Top-level certificate files
+  fs.writeFileSync(join(tempSslDir, 'fullchain.pem'), 'top-cert')
+  fs.writeFileSync(join(tempSslDir, 'privkey.pem'), 'top-key')
+  // Certificate in a subdirectory (e.g. dedicated mTLS folder)
+  fs.mkdirSync(join(tempSslDir, 'mtls'), { recursive: true })
+  fs.writeFileSync(join(tempSslDir, 'mtls', 'client.pem'), 'mtls-cert')
+  fs.writeFileSync(join(tempSslDir, 'mtls', 'client.key'), 'mtls-key')
+  ConfigPersistence.sslDir = tempSslDir
+})
+
+afterAll(() => {
+  ConfigPersistence.sslDir = originalSslDir
+  if (tempSslDir) fs.rmSync(tempSslDir, { recursive: true, force: true })
+})
+
+describe('listSslFiles (recursive)', () => {
+  it('lists top-level certificate files', () => {
+    const files = new ConfigPersistence().listSslFiles()
+    expect(files).toContain('fullchain.pem')
+    expect(files).toContain('privkey.pem')
+  })
+
+  it('lists certificates in subdirectories as relative forward-slash paths', () => {
+    const files = new ConfigPersistence().listSslFiles()
+    expect(files).toContain('mtls/client.pem')
+    expect(files).toContain('mtls/client.key')
+  })
+
+  it('does not include directory entries themselves', () => {
+    const files = new ConfigPersistence().listSslFiles()
+    expect(files).not.toContain('mtls')
+  })
+
+  it('returns empty array when sslDir is not set', () => {
+    const saved = ConfigPersistence.sslDir
+    ConfigPersistence.sslDir = ''
+    try {
+      expect(new ConfigPersistence().listSslFiles()).toEqual([])
+    } finally {
+      ConfigPersistence.sslDir = saved
+    }
+  })
+})
+
+describe('readCertificateFile', () => {
+  it('reads a top-level certificate file', () => {
+    expect(new ConfigPersistence().readCertificateFile('fullchain.pem')).toBe('top-cert')
+  })
+
+  it('reads a certificate file from a subdirectory', () => {
+    expect(new ConfigPersistence().readCertificateFile('mtls/client.pem')).toBe('mtls-cert')
+  })
+
+  it('returns undefined for a directory path', () => {
+    expect(new ConfigPersistence().readCertificateFile('mtls')).toBeUndefined()
+  })
+
+  it('refuses path traversal outside the ssl directory', () => {
+    expect(new ConfigPersistence().readCertificateFile('../../etc/passwd')).toBeUndefined()
+  })
+
+  it('returns undefined for a missing file', () => {
+    expect(new ConfigPersistence().readCertificateFile('does-not-exist.pem')).toBeUndefined()
+  })
+})

--- a/backend/tsconfig.eslint.json
+++ b/backend/tsconfig.eslint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src", "tests", "__tests__"],
+  "include": ["src", "tests"],
   "exclude": ["../dist"]
 }

--- a/backend/vitest.config.mts
+++ b/backend/vitest.config.mts
@@ -15,6 +15,11 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
+    // modbus-serial/@serialport bindings are native N-API addons that are not
+    // context-aware and cannot be loaded inside Node worker threads (they fail
+    // with "Module did not self-register"). Use the forks pool (child processes)
+    // so these tests can run. Files still run in parallel across forks.
+    pool: 'forks',
     include: ['tests/**/*_test.ts?(x)', 'tests/**/*.test.ts?(x)'],
     exclude: ['tests/**/testhelper.ts', 'tests/**/configsbase.ts', 'tests/setup/**', 'tests/integration/**'],
     hookTimeout: 30000,


### PR DESCRIPTION
This pull request improves the handling and security of SSL certificate files in the backend, adds comprehensive tests for these features, and makes minor configuration updates. The key changes include adding a recursive, secure method to list SSL files (including those in subdirectories), hardening file access against path traversal, and updating related API usage and tests.

**SSL certificate file handling and security:**

* Added a new `listSslFiles` method in `ConfigPersistence` to recursively list all certificate files in the SSL directory, returning paths relative to the root with forward slashes for UI selection. This ensures certificates in subdirectories are visible and selectable.
* Hardened `readCertificateFile` in `ConfigPersistence` to prevent path traversal attacks by ensuring requested files remain within the SSL directory and only returning file contents if the path points to a file, not a directory.

**API and server logic:**

* Updated the HTTP server's SSL files endpoint to use the new `listSslFiles` method instead of directly reading the directory, ensuring consistent and secure file listing.

**Testing improvements:**

* Added a new test suite (`config_sslfiles_test.tsx`) to verify recursive SSL file listing, correct path formatting, directory exclusion, path traversal protection, and file reading behavior.

**Configuration and test environment:**

* Changed the Vitest test runner pool to `forks` in `vitest.config.mts` to support native addons that cannot run in worker threads, improving test reliability for modules like `modbus-serial`.
* Updated the test configuration to remove the `__tests__` directory from the included paths in `tsconfig.eslint.json`.

**Other:**

* Updated a test configuration file to use a different port for a Modbus bus.