### PR TITLE
refactor: improve Modbus client connection handling and error management

### DIFF
--- a/backend/src/server/modbusAPI.ts
+++ b/backend/src/server/modbusAPI.ts
@@ -275,66 +275,56 @@ export class ModbusAPI implements IModbusAPI, IconsumerModbusAPI {
   }
 
   private connectMutex = new Mutex()
-  private connectRTUClient(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      const resolveRelease = () => {
-        this.connectMutex.release()
-        resolve()
-      }
-      const rejectRelease = (e: unknown) => {
-        this.connectMutex.release()
-        reject(e)
-      }
-      // Make sure, this modbusClient get's initialized only once. Even if called in paralell
-      this.connectMutex.acquire().then(() => {
-        if (this.modbusClient == undefined) this.modbusClient = new ModbusRTU()
-        if (this.modbusClient.isOpen) {
-          resolveRelease()
-          return
-        }
+  // Opens the modbusClient. ASSUMES connectMutex is already held by the caller.
+  // Never call this directly without the lock - use connectRTUClient() or reconnectRTU().
+  private connectRTUClientLocked(): Promise<void> {
+    if (this.modbusClient == undefined) this.modbusClient = new ModbusRTU()
+    if (this.modbusClient.isOpen) return Promise.resolve()
 
-        // debug("connectRTUBuffered")
-        const port = (this.modbusConfiguration.getModbusConnection() as IRTUConnection).serialport
-        const baudrate = (this.modbusConfiguration.getModbusConnection() as IRTUConnection).baudrate
-        if (port && baudrate) {
-          this.modbusClient.connectRTUBuffered(port, { baudRate: baudrate }).then(resolveRelease).catch(rejectRelease)
-        } else {
-          const host = (this.modbusConfiguration.getModbusConnection() as ITCPConnection).host
-          const port = (this.modbusConfiguration.getModbusConnection() as ITCPConnection).port
-          this.modbusClient.connectTCP(host, { port: port }).then(resolveRelease).catch(rejectRelease)
-        }
-      })
+    const port = (this.modbusConfiguration.getModbusConnection() as IRTUConnection).serialport
+    const baudrate = (this.modbusConfiguration.getModbusConnection() as IRTUConnection).baudrate
+    if (port && baudrate) {
+      return this.modbusClient.connectRTUBuffered(port, { baudRate: baudrate })
+    } else {
+      const host = (this.modbusConfiguration.getModbusConnection() as ITCPConnection).host
+      const tcpport = (this.modbusConfiguration.getModbusConnection() as ITCPConnection).port
+      return this.modbusClient.connectTCP(host, { port: tcpport })
+    }
+  }
+  private connectRTUClient(): Promise<void> {
+    // Serialize so the modbusClient gets initialized/opened only once, even if called in parallel.
+    return this.connectMutex.runExclusive(() => this.connectRTUClientLocked())
+  }
+  // Closes the modbusClient if open. ASSUMES connectMutex is already held.
+  private closeLocked(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      if (this.modbusClient == undefined || !this.modbusClient.isOpen) {
+        resolve()
+        return
+      }
+      this.modbusClient.close(() => resolve())
     })
   }
   reconnectRTU(task: string): Promise<void> {
-    const rc = new Promise<void>((resolve, reject) => {
+    // Serialize the WHOLE close->reopen sequence. Two concurrent reconnects (e.g. worker +
+    // updateBus) must never interleave: an overlapping open of the same serial device leaks
+    // the still-locked fd -> "Resource temporarily unavailable Cannot lock port".
+    return this.connectMutex.runExclusive(async () => {
       if (this.modbusClientTimedOut) {
-        if (this.modbusClient == undefined || !this.modbusClient.isOpen) {
-          reject(task + ' Last read failed with TIMEOUT and modbusclient is not ready')
-          return
-        } else resolve()
-      } else if (this.modbusClient == undefined || !this.modbusClient.isOpen) {
-        this.connectRTUClient()
-          .then(resolve)
-          .catch((e) => {
-            log.log(LogLevelEnum.error, task + ' connection failed ' + e)
-            reject(e)
-          })
-      } else if (this.modbusClient!.isOpen) {
-        this.modbusClient.close(() => {
-          debug('closed')
-          if (this.modbusClient!.isOpen)
-            setTimeout(() => {
-              if (this.modbusClient!.isOpen) reject(new Error('ModbusClient is open after close'))
-              else this.reconnectRTU(task).then(resolve).catch(reject)
-            }, 10)
-          else this.reconnectRTU(task).then(resolve).catch(reject)
-        })
-      } else {
-        reject(new Error(task + ' unable to open'))
+        if (this.modbusClient == undefined || !this.modbusClient.isOpen)
+          throw new Error(task + ' Last read failed with TIMEOUT and modbusclient is not ready')
+        return
+      }
+      // Always close before reopening so the previous fd (and its flock) is fully released
+      // before connectRTUBuffered creates a new SerialPort. Single owner, no overlap.
+      await this.closeLocked()
+      try {
+        await this.connectRTUClientLocked()
+      } catch (e) {
+        log.log(LogLevelEnum.error, task + ' connection failed ' + e)
+        throw e
       }
     })
-    return rc
   }
   private connectRTU(task: string): Promise<void> {
     const rc = new Promise<void>((resolve, reject) => {

--- a/backend/src/server/modbusRTUworker.ts
+++ b/backend/src/server/modbusRTUworker.ts
@@ -106,22 +106,11 @@ export class ModbusRTUWorker extends ModbusWorker {
     let maxErrors = 0
     switch (current.errorState) {
       case ModbusErrorStates.crc || ModbusErrorStates.illegaladdress:
-        if (current.errorCount >= maxErrorRetriesCrc)
-          return new Promise((resolve, _reject) => {
-            _reject(new Error('Too many retries ' + (current.errorState == ModbusErrorStates.crc ? 'crc' : 'illegal address')))
-          })
-        return new Promise<void>((resolve, _reject) => {
-          this.modbusAPI
-            .reconnectRTU('ReconnectOnError')
-            .then(() => {
-              debug('Reconnected')
-              this.executeModbusFunctionCodeRead(current).then(resolve).catch(_reject)
-            })
-            .catch((e1) => {
-              log.log(LogLevelEnum.error, 'Unable to reconnect: ' + e1.message)
-              _reject(e1)
-            })
-        })
+        // CRC/framing errors are wire-level. Reopening the (single, persistent) serial port
+        // does not fix a bad transmission and risks a second OS-level open of the same device
+        // -> "Cannot lock port". Just retry on the open port, like the timeout branch.
+        maxErrors = maxErrorRetriesCrc
+        break
       case ModbusErrorStates.timeout:
         maxErrors = maxErrorRetriesTimeout
         break
@@ -165,8 +154,9 @@ export class ModbusRTUWorker extends ModbusWorker {
     this.logErrorInCache(current, errorState)
     if (current.options.errorHandling.split && current.address.length != undefined && current.address.length > 1) {
       this.splitAddresses(current, error) // will reject if split is not possible
-      // Wait for reconnect before handling new queue entries
-      return this.modbusAPI.reconnectRTU('ReconnectOnError')
+      // Split entries are re-queued and run on the existing open port. No port reopen:
+      // a single persistent connection is the only Modbus master on the bus.
+      return new Promise((resolve) => resolve())
     } else return this.retry(current, error)
   }
 

--- a/backend/tests/server/ModbusRTUWorker_test.tsx
+++ b/backend/tests/server/ModbusRTUWorker_test.tsx
@@ -98,7 +98,7 @@ describe('ModbusRTUWorker read', () => {
     })
     test.worker = new ModbusRTUWorkerForTest(new FakeBus(), queue, done, 'read')
     const worker = test.worker
-    worker.expectedReconnected = true
+    worker.expectedReconnected = false
     worker.expectedAPIcallCount = 0
     worker.run()
     await finished
@@ -129,7 +129,7 @@ describe('ModbusRTUWorker read', () => {
     worker.run()
     await finished
   })
-  it('Sequential read error processing with reconnect', async () => {
+  it('Sequential read error processing with retry (no reconnect)', async () => {
     const queue = new ModbusRTUQueue()
     const test: Itest = {}
     queue.enqueue(
@@ -150,7 +150,7 @@ describe('ModbusRTUWorker read', () => {
     })
     test.worker = new ModbusRTUWorkerForTest(new FakeBus(), queue, done, 'read')
     const worker = test.worker
-    worker.expectedReconnected = true
+    worker.expectedReconnected = false
     worker.expectedAPIcallCount = 0
     worker.run()
     await finished
@@ -176,7 +176,7 @@ describe('ModbusRTUWorker read', () => {
     })
     test.worker = new ModbusRTUWorkerForTest(new FakeBus(), queue, done, 'read')
     const worker = test.worker
-    worker.expectedReconnected = true
+    worker.expectedReconnected = false
     worker.expectedAPIcallCount = 0
     worker.run()
     await finished


### PR DESCRIPTION
# PR Description
## Problem
Inside the LXC container the bus connection failed repeatedly:


error bus: updateBus connection failed Error Resource temporarily unavailable Cannot lock port
The serial port (/dev/ttyUSB0) stayed permanently locked and could no longer be opened.

### Root cause
The error originates in serialport (flock(LOCK_EX|LOCK_NB) → EAGAIN) and was triggered by modbus2mqtt itself — confirmed via lsof (exactly one write-locked fd, held by our own node process):

Double open within the same process. On CRC errors and on address-split, the worker called reconnectRTU('ReconnectOnError'). When this overlapped with updateBus (HTTP), connectRTUBuffered ran this._port = new SerialPort() without closing the previous port → the still-open, locked fd was leaked and blocked every subsequent open.
No serialization. The connectMutex only guarded the open, not the full close→reopen sequence in reconnectRTU, so concurrent reconnects (worker + updateBus) could overlap.
Reopening doesn't help with CRC/timeout anyway — those are wire/framing errors, not a port state. There must be exactly one persistent open (a single Modbus master). The TCP-RTU bridge is unaffected since it runs through the same queue/worker.

## Changes
backend/src/server/modbusRTUworker.ts (no more reopen on transient errors):

The CRC case in retry() now retries on the open port (like the timeout branch) instead of calling reconnectRTU.
splitWithRestartServer() no longer reconnects; the split entries run on the open port.
backend/src/server/modbusAPI.ts (harden the remaining reopen path):

reconnectRTU now runs entirely inside connectMutex.runExclusive — the whole close→open sequence is atomic, so concurrent reconnects can no longer overlap.
Always close-before-open, via new lock-free inner helpers connectRTUClientLocked() / closeLocked() (avoid deadlock when the mutex is already held).
Removed the fragile setTimeout workaround ("ModbusClient is open after close").
Verification
Hardware (LXC 504): After deploy, no more Cannot lock port; lsof /dev/ttyUSB0 shows exactly one stable handle.
Device-free: Type-check + build pass. The isolation repro serial-lock-repro.cjs confirms the library/close is sound (scenarios A/B), and only the overlapping open locks (scenario C).
