### PR TITLE
fix: add cloning of public files in M2mGitHub when directory is empty

### DIFF
--- a/backend/src/specification/m2mgithub.ts
+++ b/backend/src/specification/m2mgithub.ts
@@ -207,6 +207,20 @@ export class M2mGitHub {
     }
   }
 
+  private clonePublicFiles(): void {
+    log.log(
+      LogLevelEnum.info,
+      execSync(
+        'git clone https://github.com/' +
+          githubPublicNames.publicModbus2mqttOwner +
+          '/' +
+          githubPublicNames.modbus2mqttRepo +
+          '.git ' +
+          this.publicRoot
+      ).toString()
+    )
+  }
+
   fetchPublicFiles(): void {
     debug('Fetch public files')
     if (existsSync(this.publicRoot)) {
@@ -218,21 +232,18 @@ export class M2mGitHub {
           const msg = e instanceof Error ? e.message : String(e)
           log.log(LogLevelEnum.warn, 'git pull failed: ' + msg)
         }
+      } else if (fs.readdirSync(this.publicRoot).length == 0) {
+        // Empty directory (e.g. pre-created by the s6 init script so the addon can
+        // run non-root). git can clone into an existing empty directory, so do that
+        // instead of skipping the sync.
+        this.clonePublicFiles()
       } else {
-        log.log(LogLevelEnum.info, 'Public files directory exists, skipping git clone')
+        // Directory has content but no .git repo (test fixtures or manual setup):
+        // leave it untouched to avoid network access during tests.
+        log.log(LogLevelEnum.info, 'Public files directory exists with content, skipping git clone')
       }
     } else {
-      log.log(
-        LogLevelEnum.info,
-        execSync(
-          'git clone https://github.com/' +
-            githubPublicNames.publicModbus2mqttOwner +
-            '/' +
-            githubPublicNames.modbus2mqttRepo +
-            '.git ' +
-            this.publicRoot
-        ).toString()
-      )
+      this.clonePublicFiles()
     }
     new ConfigSpecification().readYaml()
   }

--- a/backend/tests/specification/m2mgithub_test.tsx
+++ b/backend/tests/specification/m2mgithub_test.tsx
@@ -28,6 +28,7 @@ vi.mock('fs', async () => {
   return {
     ...actual,
     existsSync: vi.fn(() => false),
+    readdirSync: vi.fn(() => []),
     mkdtempSync: vi.fn(() => '/tmp/m2m-commit-test'),
     copyFileSync: vi.fn(),
     mkdirSync: vi.fn(),
@@ -75,6 +76,29 @@ describe('M2mGitHub', () => {
       gh.fetchPublicFiles()
 
       expect(execSync).toHaveBeenCalledWith('git pull', expect.objectContaining({ cwd: '/tmp/public' }))
+    })
+
+    it('clones when publicRoot exists but is empty (e.g. pre-created by s6)', () => {
+      // publicRoot exists, but no .git inside, and the directory is empty
+      vi.mocked(fs.existsSync).mockImplementation((p) => !String(p).endsWith('.git'))
+      vi.mocked(fs.readdirSync).mockReturnValue([] as any)
+      vi.mocked(execSync).mockReturnValue(Buffer.from('Cloning...'))
+
+      const gh = new M2mGitHub(null, '/tmp/public')
+      gh.fetchPublicFiles()
+
+      expect(execSync).toHaveBeenCalledWith(expect.stringContaining('git clone'))
+    })
+
+    it('skips when publicRoot exists with content but no .git (test fixtures)', () => {
+      // publicRoot exists, no .git inside, but the directory has content
+      vi.mocked(fs.existsSync).mockImplementation((p) => !String(p).endsWith('.git'))
+      vi.mocked(fs.readdirSync).mockReturnValue(['specifications'] as any)
+
+      const gh = new M2mGitHub(null, '/tmp/public')
+      gh.fetchPublicFiles()
+
+      expect(execSync).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
This pull request improves the handling of the public files directory in the `M2mGitHub` class, ensuring that the code correctly clones the repository only when appropriate and adds tests for these scenarios. The changes make the logic more robust, especially when running in environments where the directory may be pre-created or used for testing.

**Enhancements to public files directory handling:**

* Added a new private method `clonePublicFiles()` to encapsulate the logic for cloning the public repository into `publicRoot`.
* Modified `fetchPublicFiles()` to:
  * Clone the repository if `publicRoot` exists and is empty (e.g., pre-created by an init script), instead of skipping the sync.
  * Skip cloning if `publicRoot` exists and contains files but is not a git repo, to avoid unnecessary network access during tests or manual setups.

**Testing improvements:**

* Updated the test mocks to include `readdirSync` for simulating directory contents.
* Added tests for the new behaviors:
  * Cloning when `publicRoot` exists but is empty.
  * Skipping cloning when `publicRoot` exists with content but no `.git` directory.