### PR TITLE
fix: default modbus bus timeout to 1000ms (TCP defaulted to 100ms)

### DIFF
--- a/backend/src/shared/specification/types.ts
+++ b/backend/src/shared/specification/types.ts
@@ -14,7 +14,7 @@ export enum HttpErrorsEnum {
   ErrInvalidParameter = 422,
   SrvErrInternalServerError = 500,
 }
-export const BUS_TIMEOUT_DEFAULT = 500
+export const BUS_TIMEOUT_DEFAULT = 1000
 export enum ModbusRegisterType {
   IllegalFunctionCode = 0,
   Coils = 1,

--- a/frontend/src/app/select-modbus/select-modbus.component.ts
+++ b/frontend/src/app/select-modbus/select-modbus.component.ts
@@ -294,7 +294,7 @@ export class SelectModbusComponent implements AfterViewInit, OnDestroy {
       tcp: this._formBuilder.group({
         host: ['', Validators.required],
         port: [502, Validators.required],
-        timeout: [100, Validators.required],
+        timeout: [BUS_TIMEOUT_DEFAULT, Validators.required],
       }),
     })
     return fg


### PR DESCRIPTION
## Problem

New **TCP** (and TCP-bridge) buses defaulted to a `timeout` of **100ms**, which is far too short for a Modbus device to respond — the socket connects fine (ESTABLISHED) but every read times out. This was observed against a real TCP→RTU bridge: connection up, but no readable values.

The cause: the TCP connection form hard-coded `timeout: 100` instead of using `BUS_TIMEOUT_DEFAULT`. RTU already used the constant.

## Fix

- `BUS_TIMEOUT_DEFAULT`: `500` → **`1000`** ([types.ts](backend/src/shared/specification/types.ts))
- TCP form default: hard-coded `100` → `BUS_TIMEOUT_DEFAULT` ([select-modbus.component.ts](frontend/src/app/select-modbus/select-modbus.component.ts))

New buses (RTU **and** TCP) now default to 1000ms. Existing stored bus configs keep their value.

## Testing

Backend bus tests and full frontend suite green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)