### PR TITLE
fix: display specification documents (PDF) via blob URL

### DIFF
--- a/frontend/src/app/specification/upload-files/upload-files.component.ts
+++ b/frontend/src/app/specification/upload-files/upload-files.component.ts
@@ -1,4 +1,4 @@
-import { OnChanges, Component, Input, ViewChild, Output, EventEmitter, OnInit } from '@angular/core'
+import { OnChanges, Component, Input, ViewChild, Output, EventEmitter, OnInit, OnDestroy } from '@angular/core'
 import { FormBuilder, FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { GalleryItem, ImageItem, GalleryComponent } from 'ng-gallery'
 import {
@@ -46,7 +46,7 @@ import {
     GalleryComponent
 ],
 })
-export class UploadFilesComponent implements OnInit, OnChanges {
+export class UploadFilesComponent implements OnInit, OnChanges, OnDestroy {
   constructor(
     private fb: FormBuilder
   ) {
@@ -180,11 +180,36 @@ export class UploadFilesComponent implements OnInit, OnChanges {
     btn.disabled = !event.target || (event.target as any).value == null || (event.target as any).value == ''
   }
 
+  // Object URLs created from embedded base64 data, cached per file. They are created in the
+  // generate* methods (not in the template-bound getter), so the getter returns a stable value
+  // during change detection. Revoked on destroy.
+  private blobUrlCache = new Map<IimageAndDocumentUrl, string>()
+
+  // Pure read used by the template: never creates a URL during change detection.
   getFileDisplayUrl(file: IimageAndDocumentUrl): string {
-    if (file.fileLocation === FileLocation.Local && file.data) {
-      return `data:${file.mimeType || 'application/octet-stream'};base64,${file.data}`
+    return this.blobUrlCache.get(file) ?? file.url
+  }
+
+  // A data: URL cannot be used as an <a href> target: browsers block top-level navigation to
+  // data: URLs, so opening a document (e.g. a PDF) in a new tab does nothing. A blob: object URL
+  // is navigable and works for both <a href> and <img src>. Created once per file and cached.
+  private ensureBlobUrl(file: IimageAndDocumentUrl): void {
+    if (file.fileLocation === FileLocation.Local && file.data && !this.blobUrlCache.has(file)) {
+      const blob = this.base64ToBlob(file.data, file.mimeType || 'application/octet-stream')
+      this.blobUrlCache.set(file, URL.createObjectURL(blob))
     }
-    return file.url
+  }
+
+  private base64ToBlob(base64: string, mimeType: string): Blob {
+    const binary = atob(base64)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+    return new Blob([bytes], { type: mimeType })
+  }
+
+  ngOnDestroy(): void {
+    for (const url of this.blobUrlCache.values()) URL.revokeObjectURL(url)
+    this.blobUrlCache.clear()
   }
 
   generateDocumentUrls() {
@@ -192,15 +217,22 @@ export class UploadFilesComponent implements OnInit, OnChanges {
     if (this.currentSpecification && this.currentSpecification.files)
       for (let i = 0; i < this.currentSpecification.files.length; i++) {
         const doc = this.currentSpecification.files[i]
-        if (doc.usage == SpecificationFileUsage.documentation) rc.push(doc)
+        if (doc.usage == SpecificationFileUsage.documentation) {
+          this.ensureBlobUrl(doc)
+          rc.push(doc)
+        }
       }
-    if (rc.length != this.documentUrls.length) this.documentUrls = rc
+    // Always reassign (like generateImageGalleryItems). Comparing only by length kept a
+    // stale document when switching between two specs that each have the same number of
+    // documents, so the new spec's document was never shown.
+    this.documentUrls = rc
   }
   generateImageGalleryItems(): void {
     const rc: GalleryItem[] = []
     const rd: IimageAndDocumentUrl[] = []
     this.currentSpecification?.files.forEach((img) => {
       if (img.usage == SpecificationFileUsage.img) {
+        this.ensureBlobUrl(img)
         const displayUrl = this.getFileDisplayUrl(img)
         rc.push(new ImageItem({ src: displayUrl, thumb: displayUrl }))
         rd.push(img)

--- a/frontend/src/app/specification/upload-files/upload-files.component.vitest.spec.ts
+++ b/frontend/src/app/specification/upload-files/upload-files.component.vitest.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest'
+
+;(globalThis as any).$localize = (parts: TemplateStringsArray, ...args: any[]) =>
+  parts.reduce((acc, p, i) => acc + p + (i < args.length ? args[i] : ''), '')
+
+vi.mock('ng-gallery', async () => {
+  const { Component } = await import('@angular/core')
+  @Component({ selector: 'gallery', standalone: true, template: '' })
+  class GalleryStub {}
+  return {
+    GalleryComponent: GalleryStub,
+    GalleryItem: class {},
+    ImageItem: class {
+      data: any
+      constructor(d: any) {
+        this.data = d
+      }
+    },
+  }
+})
+
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { UploadFilesComponent } from './upload-files.component'
+import { FileLocation, SpecificationFileUsage } from '@shared/specification'
+import { ensureAngularTesting } from '../../../test-setup'
+
+ensureAngularTesting()
+
+function makeSpec(): any {
+  return {
+    filename: 'waterlevelsensor',
+    entities: [],
+    i18n: [],
+    files: [
+      {
+        url: 'specifications/files/waterlevelsensor/waterleveltransmitter.pdf',
+        fileLocation: FileLocation.Local,
+        usage: SpecificationFileUsage.documentation,
+        data: 'JVBERi0xLjQNCg==',
+        mimeType: 'application/pdf',
+      },
+      {
+        url: 'specifications/files/waterlevelsensor/waterlevel.jpg',
+        fileLocation: FileLocation.Local,
+        usage: SpecificationFileUsage.img,
+        data: '/9j/4AAQSkZJRg==',
+        mimeType: 'image/jpeg',
+      },
+    ],
+  }
+}
+
+describe('UploadFilesComponent documents (vitest)', () => {
+  async function mount(): Promise<ComponentFixture<UploadFilesComponent>> {
+    await TestBed.configureTestingModule({
+      imports: [UploadFilesComponent],
+    }).compileComponents()
+    return TestBed.createComponent(UploadFilesComponent)
+  }
+
+  it('renders the document link with a navigable (blob:) href, not a blocked data: URL', async () => {
+    const fixture = await mount()
+    fixture.componentInstance.currentSpecification = makeSpec()
+    fixture.componentInstance.ngOnChanges() // simulate @Input change
+    fixture.detectChanges()
+
+    expect(fixture.componentInstance.documentUrls.length).toBe(1)
+    // Browsers block top-level navigation to data: URLs, so opening a PDF in a new tab does
+    // nothing. The href must be a navigable blob: object URL.
+    const docHref = fixture.componentInstance.getFileDisplayUrl(fixture.componentInstance.documentUrls[0])
+    expect(docHref.startsWith('data:')).toBe(false)
+    expect(docHref.startsWith('blob:')).toBe(true)
+  })
+
+  it('switch spec A(1 doc) -> B(1 doc): document list updates (no stale doc)', async () => {
+    const fixture = await mount()
+    const specA = makeSpec()
+    specA.files[0].url = 'specifications/files/A/aaa.pdf'
+    specA.files[0].data = 'QQ=='
+    fixture.componentInstance.currentSpecification = specA
+    fixture.componentInstance.ngOnChanges()
+    expect(fixture.componentInstance.documentUrls[0]?.url).toBe('specifications/files/A/aaa.pdf')
+
+    // Switch to waterlevelsensor (also exactly 1 document). A length-only comparison kept
+    // spec A's document here, so the new spec's document was never shown.
+    fixture.componentInstance.currentSpecification = makeSpec()
+    fixture.componentInstance.ngOnChanges()
+    expect(fixture.componentInstance.documentUrls[0]?.url).toContain('waterleveltransmitter.pdf')
+  })
+})

--- a/modbus2mqtt.code-workspace
+++ b/modbus2mqtt.code-workspace
@@ -59,14 +59,20 @@
         "type": "shell",
         "command": "pnpm",
         "args": ["run", "build"],
-        "options": { "cwd": "${workspaceFolder:modbus2mqtt}" },
+        "options": {
+          "cwd": "${workspaceFolder:modbus2mqtt}",
+          "env": { "PATH": "${env:HOME}/.nvm/versions/node/v22.12.0/bin:${env:PATH}" },
+        },
         "problemMatcher": [],
       },
       {
         "label": "ng serve debug",
         "type": "shell",
         "command": "npx ng serve --configuration debug --host localhost --port 3602",
-        "options": { "cwd": "${workspaceFolder:frontend}" },
+        "options": {
+          "cwd": "${workspaceFolder:frontend}",
+          "env": { "PATH": "${env:HOME}/.nvm/versions/node/v22.12.0/bin:${env:PATH}" },
+        },
         "isBackground": true,
         "detail": "Angular dev server on http://localhost:3602 (proxies API to backend :3601)",
         "presentation": { "reveal": "always", "panel": "dedicated" },
@@ -127,6 +133,7 @@
       {
         "name": "Run Modbus2mqtt Server (OIDC)",
         "preLaunchTask": "build modbus2mqtt",
+        "runtimeVersion": "22.12",
         "timeout": 10000,
         "program": "${workspaceFolder:modbus2mqtt}/dist/server/modbus2mqtt.js",
         "args": ["-s", "../certs", "-c", "../config-dir", "-d", "../data-dir"],
@@ -142,6 +149,7 @@
       {
         "name": "Debug Backend (HTTP :3601)",
         "preLaunchTask": "build modbus2mqtt",
+        "runtimeVersion": "22.12",
         "timeout": 10000,
         "program": "${workspaceFolder:modbus2mqtt}/dist/server/modbus2mqtt.js",
         "args": ["-c", "../config-dir", "-d", "../data-dir", "-s", "../certs"],


### PR DESCRIPTION
## Problem

After migrating specifications to a single JSON file, attached files (PDFs, images) are embedded as base64. The document link in the specification editor rendered that data as a `data:` URL in the `<a href>`. Browsers block top-level navigation to `data:` URLs, so clicking an attached document (e.g. `waterleveltransmitter.pdf` on the `waterlevelsensor` spec) did nothing. Images kept working because they render via `<img src>`, which is not navigation.

The backend embeds the document correctly — this is purely a frontend rendering issue.

## Fix

- `upload-files.component.ts`: build a navigable `blob:` object URL from the base64 data instead of a `data:` URL. Created once per file and cached (the getter is template-bound and runs on every change-detection cycle), revoked in `ngOnDestroy`.
- Fix `generateDocumentUrls()` reassigning `documentUrls` only when the array length changed, which kept a stale document when switching between two specs that each have the same number of documents (now always reassigns, like the image path).
- Add a vitest spec asserting the document href is a navigable `blob:` URL (not a blocked `data:` URL) and that the document list updates on spec switch.

## Tooling (modbus2mqtt.code-workspace)

VS Code launch configs now set `runtimeVersion` and prepend the nvm bin to the task `PATH`, so the Node debugger and `ng serve` find the nvm-managed Node when VS Code is launched from the GUI (which doesn't inherit the shell's nvm PATH).

## Test

All frontend vitest tests pass (17), including the new `upload-files.component.vitest.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)