### PR TITLE
fix: show error when new slave uses an existing slave id

### DIFF
--- a/frontend/src/app/select-slave/select-slave.component.html
+++ b/frontend/src/app/select-slave/select-slave.component.html
@@ -337,7 +337,16 @@
           <mat-card-content>
             <mat-form-field class="field width150pt">
               <mat-label>Slave Id</mat-label>
-              <input matInput name="slaveId" formControlName="slaveId" type="number" />
+              <input
+                matInput
+                name="slaveId"
+                formControlName="slaveId"
+                type="number"
+                [errorStateMatcher]="errorStateMatcher"
+              />
+              @if (slaveNewForm.get('slaveId')!.hasError('duplicate')) {
+                <mat-error> Slave Id already exists </mat-error>
+              }
             </mat-form-field>
             <mat-slide-toggle class="width50" formControlName="detectSpec" [matTooltip]="getDetectSpecToolTip()"
               >Enable Specification matching.</mat-slide-toggle

--- a/frontend/src/app/select-slave/select-slave.component.ts
+++ b/frontend/src/app/select-slave/select-slave.component.ts
@@ -131,7 +131,7 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
   ) {
     super()
     this.slaveNewForm = this._formBuilder.group({
-      slaveId: [null],
+      slaveId: [null, this.duplicateSlaveIdValidator],
       detectSpec: [false],
     })
   }
@@ -462,6 +462,15 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
   uniqueNameValidator: any = (slaveId: number, control: AbstractControl): ValidationErrors | null => {
     if (this.hasDuplicateName(slaveId, control.value)) return { duplicates: control.value }
     else return null
+  }
+
+  duplicateSlaveIdValidator: any = (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value
+    if (value === null || value === undefined || value === '') return null
+    const slaveId = parseInt(value)
+    if (isNaN(slaveId) || slaveId < 0) return null
+    const exists = this.uiSlaves.find((uis) => uis != null && uis.slave.slaveid != null && uis.slave.slaveid == slaveId)
+    return exists ? { duplicate: slaveId } : null
   }
 
   deleteSlave(slave: Islave | null) {


### PR DESCRIPTION
## Problem

On the **New Slave** card (`/slaves/:busid`), entering an already-used slave address correctly prevents creation — but the only feedback is a disabled "Add Modbus Slave" button. The user has no visible explanation for why the slave can't be created.

## Fix

Add a `duplicate` validator to the `slaveId` control plus a `mat-error`, mirroring the existing duplicate-**name** pattern already used for the slave name field:

- `duplicateSlaveIdValidator` marks the field invalid when the entered id already exists in `uiSlaves`.
- The input now uses the shared `errorStateMatcher` and shows **"Slave Id already exists"** when the id is a duplicate.

The add button stays disabled on a duplicate (unchanged, intended behavior) — now the user understands why.

## Notes

- Message text is English, consistent with the rest of the component's UI ("Must be unique", "New Slave").
- Verified via `ng build` (green). Not clicked through in a running browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)