### PR TITLE
fix: harden MQTT error handling and HTTP redirect, fix frontend debug base href

### DIFF
--- a/backend/src/server/http/httpServerBase.ts
+++ b/backend/src/server/http/httpServerBase.ts
@@ -74,7 +74,10 @@ export class HttpServerBase {
         redirectApp.all(/.*/, (req: Request, res: express.Response) => {
           const host = req.hostname
           const httpsUrl = `https://${host}:${httpsPort}${req.originalUrl}`
-          res.redirect(301, httpsUrl)
+          // 302 (temporary), never 301: the same HTTP port serves the app directly in
+          // HTTP-only/debug mode, and browsers cache a 301 permanently — a cached 301 would
+          // keep redirecting to an HTTPS port that is no longer listening.
+          res.redirect(302, httpsUrl)
         })
         this.server = redirectApp.listen(config.httpport, () => {
           log.log(LogLevelEnum.info, `HTTP redirecting to HTTPS on port ${config.httpport}`)

--- a/backend/src/server/mqttconnector.ts
+++ b/backend/src/server/mqttconnector.ts
@@ -9,11 +9,18 @@ import Debug from 'debug'
 const log = new Logger('mqttconnector')
 const debugMqttClient = Debug('mqttclient')
 const debug = Debug('mqttconnector')
+// Minimum time between repeats of the SAME MQTT connection error in the log. A broker that
+// keeps rejecting every reconnectPeriod (e.g. missing client certificate) would otherwise
+// flood the log once per second; a changed error is still logged immediately.
+const mqttErrorLogIntervalMs = 60000
 
 export class MqttConnector {
   private client?: MqttClient
   private subscribedSlaves: Slave[] = []
   private isSubscribed: boolean
+  // The last connection error we logged and when, used to throttle identical repeats.
+  private lastErrorMessage: string | undefined
+  private lastErrorLoggedAt: number = 0
   private onMqttMessageListeners: ((topic: string, payload: Buffer) => Promise<void>)[] = []
   private onConnectListener: ((mqttClient: MqttClient) => void)[] = []
   onConnectCallbacks: ((connection: MqttClient) => void)[]
@@ -52,7 +59,17 @@ export class MqttConnector {
     }
   }
   private handleErrors(e: Error) {
-    log.log(LogLevelEnum.error, 'MQTT error: ' + e.message)
+    const message = 'MQTT error: ' + e.message
+    const now = Date.now()
+    // Throttle identical errors: the mqtt client re-emits the same error on every reconnect
+    // attempt (once per reconnectPeriod). Log it at most once per mqttErrorLogIntervalMs, but
+    // log a changed error immediately so real state changes are never hidden. Time-based on
+    // purpose: the 'connect'/'reconnect' events flap during such an outage, so they can't be
+    // used to reliably detect recovery.
+    if (message === this.lastErrorMessage && now - this.lastErrorLoggedAt < mqttErrorLogIntervalMs) return
+    this.lastErrorMessage = message
+    this.lastErrorLoggedAt = now
+    log.log(LogLevelEnum.error, message)
   }
   private onConnect(mqttClient: MqttClient) {
     debug('reconnecting MQTT')
@@ -139,7 +156,16 @@ export class MqttConnector {
         this.client.removeAllListeners('connect')
         this.client.on('error', this.handleErrors.bind(this))
         this.onMqttMessageListeners.forEach((listener) => {
-          this.client!.on('message', listener)
+          // The mqtt 'message' event ignores the promise a listener returns. Await it here so
+          // a handler that rejects (e.g. a publish issued while the client is disconnecting)
+          // is logged instead of surfacing as an unhandled promise rejection.
+          this.client!.on('message', async (topic: string, payload: Buffer) => {
+            try {
+              await listener(topic, payload)
+            } catch (e) {
+              log.log(LogLevelEnum.error, 'MQTT message handler failed: ' + (e instanceof Error ? e.message : String(e)))
+            }
+          })
         })
         this.client.on('connect', this.onConnect.bind(this, this.client))
         this.client.on('reconnect', this.onConnect.bind(this, this.client))

--- a/backend/src/server/mqttsubscriptions.ts
+++ b/backend/src/server/mqttsubscriptions.ts
@@ -235,25 +235,20 @@ export class MqttSubscriptions {
     return this.subscribedSlaves.filter((s) => s.getBusId() == busid)
   }
   // returns a promise for testing
-  private onMqttMessage(topic: string, payload: Buffer): Promise<void> {
-    if (topic) {
-      debug('onMqttMessage: ' + topic)
-      const s = this.subscribedSlaves.find((s) => topic.startsWith(s.getBaseTopic()!))
-      if (s) {
-        if (s.getTriggerPollTopic() == topic) {
-          debug('Triggering Poll')
-          return this.publishState(s).then(() => undefined)
-        } else if (payload != undefined && payload != null) {
-          if (topic == s.getCommandTopic()) return this.sendCommand(s, payload.toString('utf-8')).then(() => undefined)
-          else if (topic.startsWith(s.getBaseTopic()) && topic.indexOf('/set/') != -1) {
-            return this.sendEntityCommandWithPublish(s, topic, payload.toString('utf-8')).then(() => undefined)
-          }
-        }
+  private async onMqttMessage(topic: string, payload: Buffer): Promise<void> {
+    if (!topic) return
+    debug('onMqttMessage: ' + topic)
+    const s = this.subscribedSlaves.find((s) => topic.startsWith(s.getBaseTopic()!))
+    if (!s) return
+    if (s.getTriggerPollTopic() == topic) {
+      debug('Triggering Poll')
+      await this.publishState(s)
+    } else if (payload != undefined && payload != null) {
+      if (topic == s.getCommandTopic()) await this.sendCommand(s, payload.toString('utf-8'))
+      else if (topic.startsWith(s.getBaseTopic()) && topic.indexOf('/set/') != -1) {
+        await this.sendEntityCommandWithPublish(s, topic, payload.toString('utf-8'))
       }
     }
-    return new Promise<void>((resolve) => {
-      resolve()
-    })
   }
 
   // Expose command handling for tests invoking this method dynamically

--- a/backend/tests/server/httpserver_https_test.tsx
+++ b/backend/tests/server/httpserver_https_test.tsx
@@ -134,13 +134,18 @@ describe('HTTPS server', () => {
             .get(`https://localhost:${httpsPort}/`, { agent }, (res) => {
               expect(res.statusCode).toBe(200)
 
-              // HTTP redirects to HTTPS
+              // HTTP redirects to HTTPS (302 temporary, see httpServerBase redirect handler)
               http.get(`http://localhost:${httpPort}/test`, (httpRes) => {
-                expect(httpRes.statusCode).toBe(301)
-                expect(httpRes.headers.location).toContain(`https://`)
-                expect(httpRes.headers.location).toContain(String(httpsPort))
-                server.close()
-                resolve()
+                try {
+                  expect(httpRes.statusCode).toBe(302)
+                  expect(httpRes.headers.location).toContain(`https://`)
+                  expect(httpRes.headers.location).toContain(String(httpsPort))
+                  server.close()
+                  resolve()
+                } catch (err) {
+                  server.close()
+                  reject(err)
+                }
               })
             })
             .on('error', (err) => {

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -38,6 +38,12 @@
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true
+            },
+            "debug": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "baseHref": "/"
             }
           },
           "defaultConfiguration": "production"
@@ -55,7 +61,7 @@
               "proxyConfig": "proxy.conf.3005.json"
             },
             "debug": {
-              "buildTarget": "modbus2mqtt:build:development",
+              "buildTarget": "modbus2mqtt:build:debug",
               "proxyConfig": "proxy.conf.3601.json",
               "host": "localhost",
               "port": 3602


### PR DESCRIPTION
## Backend robustness

- **MQTT error flooding**: `mqttconnector` now throttles repeated *identical* connection errors — logged at most once per minute instead of once per reconnect interval. A broker that keeps rejecting (e.g. missing client certificate) previously spammed the log every second.
- **Unhandled promise rejection**: the MQTT `message` event ignores the promise a listener returns. When a publish is issued while the client is disconnecting, `client.publish` throws synchronously → the rejection surfaced as an *unhandled rejection* (can crash the process). The listener is now awaited inside a `try/catch`, and `onMqttMessage` was rewritten from `.then()` chains to `async/await`.
- **301 → 302 redirect**: the HTTP→HTTPS redirect used `301` (permanent). Browsers cache a 301 forever, so once seen it keeps redirecting to an HTTPS port that no longer listens in HTTP-only/debug mode. Now `302` (temporary).

## Dev tooling

- **Frontend debug base href**: added a `debug` build configuration (`baseHref: "/"`) and pointed the `debug` serve target at it. Deep-link reloads (e.g. `/slaves/0`) on the ng-serve dev server now resolve assets from root instead of `/slaves/styles.css` (which fell through to the SPA index.html → wrong MIME type).
  - Production / Home Assistant are **unaffected**: they keep the relative `./` base href, which the backend (`AngularStatics.sendIndexFile`) rewrites to the absolute ingress path at serve time.

## Verification

- Backend builds; MQTT tests green (14 passed / 5 skipped).
- Verified against a throwaway dev server: `/slaves/0` serves `<base href="/">` and `/styles.css` returns `200 text/css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)