### PR TITLE
fix: sort slaves numerically by slaveid

### DIFF
--- a/backend/src/server/persistence/busPersistence.ts
+++ b/backend/src/server/persistence/busPersistence.ts
@@ -44,6 +44,8 @@ export class BusPersistence implements ICollectionPersistence<IBus> {
               }
             })
 
+            bus.slaves.sort((a, b) => a.slaveid - b.slaveid)
+
             busses.push(bus)
           } catch (e: unknown) {
             if (e instanceof Error) {


### PR DESCRIPTION
## Problem

Under `/slaves/N` the slaves were sorted by `slaveid` as a **string** (e.g. `1, 10, 11, 2, 3`) instead of numerically.

## Cause

The frontend takes the slave order verbatim from the backend. The backend reads slaves from disk via `fs.readdirSync` on files named `s<slaveid>.yaml`, which returns filenames in **lexicographic** order (`s1.yaml, s10.yaml, s2.yaml, ...`).

## Fix

Sort `bus.slaves` numerically by `slaveid` after loading in `busPersistence.readAll()`.

## Testing

All backend tests pass (383 passed, 7 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)