### PR TITLE
fix: small entity/MQTT-ID UI fixes

### DIFF
--- a/frontend/src/app/specification/entity-value-control/entity-value-control.component.html
+++ b/frontend/src/app/specification/entity-value-control/entity-value-control.component.html
@@ -1,5 +1,5 @@
 @if (getConverterName() == 'number') {
-  <mat-form-field class="width100pt">
+  <mat-form-field class="width150pt">
     <mat-label>MQTT Value</mat-label>
     <input
       matInput

--- a/frontend/src/app/specification/entity-value-control/entity-value-control.component.ts
+++ b/frontend/src/app/specification/entity-value-control/entity-value-control.component.ts
@@ -145,6 +145,10 @@ export class EntityValueControlComponent implements OnInit, OnDestroy, OnChanges
           if (this.entity.mqttValue) fc.setValue(this.entity.mqttValue == 'ON')
           break
         case 'value':
+          // Static value (no modbus address): show the computed mqttValue read-only.
+          fc = this.textFormControl
+          if (this.entity.mqttValue != undefined) fc.setValue(this.getMqttValue().toString())
+          break
       }
       if (fc)
         if (this.entity.readonly) fc.disable()

--- a/frontend/src/app/specification/entity/entity.component.html
+++ b/frontend/src/app/specification/entity/entity.component.html
@@ -114,7 +114,7 @@
               />
               <mat-icon
                 matSuffix
-                matTooltip="Name of this value in the MQTT payload. A dot nests the value: &quot;obis.obis_value&quot; produces a nested obis → obis_value object; use [n] for array items, e.g. &quot;values[0]&quot;. Allowed characters: letters, digits, _ - . [ ]. A slash '/' is not allowed (it is the MQTT topic separator and breaks discovery and command topics)."
+                matTooltip="Name of this value in the MQTT payload. A dot nests the value: &quot;obis.obis_value&quot; produces a nested obis → obis_value object. Use [n] to build an array of objects: two entities named &quot;obis[0].obis_key&quot; and &quot;obis[0].obis_value&quot; produce obis: [ { obis_key, obis_value } ]; &quot;obis[1]…&quot; adds a second array item. Allowed characters: letters, digits, _ - . [ ]. A slash '/' is not allowed (it is the MQTT topic separator and breaks discovery and command topics)."
                 >info_outline</mat-icon
               >
 

--- a/frontend/src/app/specification/entity/entity.component.html
+++ b/frontend/src/app/specification/entity/entity.component.html
@@ -112,6 +112,11 @@
                 [errorStateMatcher]="errorStateMatcher"
                 (change)="onEntityNameValueChange()"
               />
+              <mat-icon
+                matSuffix
+                matTooltip="Name of this value in the MQTT payload. A dot nests the value: &quot;obis.obis_value&quot; produces a nested obis → obis_value object; use [n] for array items, e.g. &quot;values[0]&quot;. Allowed characters: letters, digits, _ - . [ ]. A slash '/' is not allowed (it is the MQTT topic separator and breaks discovery and command topics)."
+                >info_outline</mat-icon
+              >
 
               @if (entityFormGroup!.get('mqttname')?.hasError('unique') != null) {
                 <mat-error> Must be unique within table </mat-error>

--- a/frontend/src/app/specification/entity/entity.component.ts
+++ b/frontend/src/app/specification/entity/entity.component.ts
@@ -43,7 +43,7 @@ import { MatOption } from '@angular/material/core'
 import { MatSelect } from '@angular/material/select'
 import { MatSlideToggle } from '@angular/material/slide-toggle'
 import { MatInput } from '@angular/material/input'
-import { MatFormField, MatLabel, MatError } from '@angular/material/form-field'
+import { MatFormField, MatLabel, MatError, MatSuffix } from '@angular/material/form-field'
 import { MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle } from '@angular/material/expansion'
 import { EntityValueControlComponent } from '../entity-value-control/entity-value-control.component'
 import { MatIcon } from '@angular/material/icon'
@@ -89,6 +89,7 @@ const newEntity: ImodbusEntityWithName = {
     MatIconButton,
     MatTooltip,
     MatIcon,
+    MatSuffix,
     NgClass,
     EntityValueControlComponent,
     MatCardContent,

--- a/frontend/src/app/specification/entity/entity.component.ts
+++ b/frontend/src/app/specification/entity/entity.component.ts
@@ -114,10 +114,14 @@ export class EntityComponent extends SessionStorage implements AfterViewInit, On
     _event.target.value = 'YYYY'
   }
   onMqttKeyPress($event: KeyboardEvent) {
+    // Allowed in MQTT topics and Home Assistant discovery object_ids: [a-zA-Z0-9_-].
+    // '_' and '-' are valid; only the wildcards '+'/'#' and the level separator '/' are not.
     if (
       !('a' <= $event.key && $event.key <= 'z') &&
       !('A' <= $event.key && $event.key <= 'Z') &&
-      !('0' <= $event.key && $event.key <= '9')
+      !('0' <= $event.key && $event.key <= '9') &&
+      $event.key !== '_' &&
+      $event.key !== '-'
     ) {
       $event.stopImmediatePropagation()
       return false

--- a/frontend/src/app/specification/entity/entity.component.ts
+++ b/frontend/src/app/specification/entity/entity.component.ts
@@ -113,15 +113,19 @@ export class EntityComponent extends SessionStorage implements AfterViewInit, On
   onMqttValueChange(_event: any, _entity: ImodbusEntity) {
     _event.target.value = 'YYYY'
   }
+  // Characters permitted in an entity mqttname. Besides [a-zA-Z0-9]:
+  //   '_' '-'   valid in MQTT topics and Home Assistant object_ids
+  //   '.' '[' ']'  structured mqttname: nest the value in the payload, e.g. "obis.obis_value"
+  //               or "arr[0]" (see Slave.parseMqttPath); discovery slugifies these for object_id.
+  // '/' stays blocked: it is the MQTT topic level separator and breaks the command topic
+  // filter (base/+/set/#), the Jinja2 value_template (division) and the HA object_id.
+  private static readonly mqttNameExtraChars = new Set(['_', '-', '.', '[', ']'])
   onMqttKeyPress($event: KeyboardEvent) {
-    // Allowed in MQTT topics and Home Assistant discovery object_ids: [a-zA-Z0-9_-].
-    // '_' and '-' are valid; only the wildcards '+'/'#' and the level separator '/' are not.
     if (
       !('a' <= $event.key && $event.key <= 'z') &&
       !('A' <= $event.key && $event.key <= 'Z') &&
       !('0' <= $event.key && $event.key <= '9') &&
-      $event.key !== '_' &&
-      $event.key !== '-'
+      !EntityComponent.mqttNameExtraChars.has($event.key)
     ) {
       $event.stopImmediatePropagation()
       return false


### PR DESCRIPTION
Sammlung kleiner, unabhängiger Frontend-Fixes rund um Entities und die MQTT ID.

## Änderungen

1. **Number-Feld verbreitert** — das MQTT-Value-Number-Feld war fix 100px breit und schnitt große Zahlen (z. B. voller uint32) ab. Jetzt 150px, konsistent mit den Text-/Select-Feldern.

2. **MQTT ID erlaubt `_` und `-`** — der Keypress-Filter ließ nur `[a-zA-Z0-9]` zu. Beide Zeichen sind in MQTT-Topics und Home-Assistant-`object_id`s gültig.

3. **MQTT ID erlaubt `.` `[` `]`** — nötig, um das bereits in `main` (via #254) vorhandene *structured mqttname*-Feature zu nutzen: `obis.obis_value` → `{ obis: { obis_value } }`, `obis[0].obis_key` → Array-von-Objekten. `/` bleibt bewusst blockiert (MQTT-Level-Trenner; bricht Command-Topic-Filter, Jinja2-`value_template` und HA-`object_id`).

4. **Static-Value-Anzeige** — der `value`-Konverter (statischer Wert ohne Modbus-Adresse) hatte einen leeren `case 'value':`; das readonly „MQTT Value"-Feld blieb leer. Wird jetzt aus dem berechneten `mqttValue` befüllt.

5. **Tooltip für MQTT ID** — Info-Icon, das die Punkt-/Array-Notation erklärt (inkl. OBIS-Array-Beispiel), da sie nicht selbsterklärend ist.

## Tests

- Frontend: 18/18 grün.
- Auf aktuellen `main` rebased (nach #254).

🤖 Generated with [Claude Code](https://claude.com/claude-code)