### PR TITLE
feat: POST Body Example preview in slave HTTP Push section

### DIFF
--- a/backend/src/shared/server/Slave.ts
+++ b/backend/src/shared/server/Slave.ts
@@ -247,12 +247,14 @@ export class Slave {
   // e.g. { "obis": "1-0:1.0.8", "obis_value": 234 }.
   // Builds the HTTP push payload from the selected push entities. If httpPush.root is set, only that
   // subtree is returned; returns null when the root path is not present so the caller skips the push.
-  getHttpPushPayload(entities: ImodbusEntity[]): string | null {
+  // defaultValue substitutes entities without a mqttValue (used by the UI preview to show the shape
+  // with placeholders); the real push passes nothing, so unset values are omitted as before.
+  getHttpPushPayload(entities: ImodbusEntity[], defaultValue?: string | null): string | null {
     const pushEntities = this.slave.httpPush?.pushEntities ?? []
     const holder: { value: unknown } = { value: undefined }
     for (const e of entities) {
       if (e.mqttname != undefined && e.mqttname.length > 0 && e.variableConfiguration == undefined && pushEntities.includes(e.id)) {
-        Slave.setByPath(holder, Slave.parseMqttPath(e.mqttname), e.mqttValue)
+        Slave.setByPath(holder, Slave.parseMqttPath(e.mqttname), e.mqttValue != undefined ? e.mqttValue : defaultValue)
       }
     }
     if (holder.value == undefined) holder.value = {}

--- a/frontend/src/app/select-slave/select-slave.component.html
+++ b/frontend/src/app/select-slave/select-slave.component.html
@@ -373,6 +373,8 @@
                       <mat-list-option [value]="selected.id">{{ selected.name }}</mat-list-option>
                     }
                   </mat-selection-list>
+                  <h2>POST Body Example</h2>
+                  <textarea rows="10" cols="20" readonly>{{ getHttpPushBody(uislave) }}</textarea>
                 </mat-expansion-panel>
               }
               <mat-expansion-panel>

--- a/frontend/src/app/select-slave/select-slave.component.ts
+++ b/frontend/src/app/select-slave/select-slave.component.ts
@@ -330,6 +330,23 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
     const spec = sl.getSpecification()
     return spec ? sl.getStatePayload(spec.entities as any, '') : ''
   }
+  // Preview of the HTTP POST body for the currently selected push entities / root, built from the
+  // live form values so the selection influences the output immediately. Values are placeholders
+  // (empty strings) like the state payload example, since the spec carries no runtime mqttValue here.
+  getHttpPushBody(uiSlave: IuiSlave): string | undefined {
+    if (!this.config || !this.bus) return undefined
+    const url: string | null = uiSlave.slaveForm.get('httpPushUrl')!.value
+    if (!url || url.length === 0) return ''
+    const root: string | null = uiSlave.slaveForm.get('httpPushRoot')!.value
+    const pushEntities: number[] = uiSlave.slaveForm.get('pushEntitiesList')!.value ?? []
+    const httpPush: any = { url, pushEntities }
+    if (root && root.length > 0) httpPush.root = root
+    const sl = new Slave(this.bus.busId, { ...uiSlave.slave, httpPush }, this.config.mqttbasetopic)
+    const spec = sl.getSpecification()
+    if (!spec) return ''
+    const body = sl.getHttpPushPayload(spec.entities as any, '')
+    return body != null ? body : `(root "${root}" not found in the payload)`
+  }
   getTriggerPollTopic(uiSlave: IuiSlave): string | undefined {
     if (!this.config || !this.bus) return undefined
     const sl = new Slave(this.bus.busId, uiSlave.slave, this.config.mqttbasetopic)


### PR DESCRIPTION
## Was

Ergänzt in der Slaves-UI (HTTP-Push-Sektion) ein Feld **"POST Body Example"** — analog zum bestehenden **"State Payload Example"** —, das den generierten HTTP-POST-Body zeigt.

Das Feld steht **unterhalb der Entity-Selektion**, weil Auswahl und Root-Pfad die Ausgabe direkt beeinflussen: Es wird aus den **Live-Formularwerten** (`pushEntitiesList`, `httpPushRoot`) gebaut und aktualisiert sich sofort bei Änderung der Auswahl.

## Wie

- `Slave.getHttpPushPayload()` bekommt einen optionalen `defaultValue`. Damit kann die Vorschau die Struktur mit Platzhaltern (leere Strings) anzeigen, wenn die Spec hier keine Laufzeit-`mqttValue` trägt — genau wie das State-Payload-Beispiel. Der echte Push übergibt keinen Default, ungesetzte Werte werden also weiterhin weggelassen (Verhalten unverändert).
- Frontend: neue Methode `getHttpPushBody(uiSlave)` in `select-slave.component.ts` + Textarea im Template.

Beispiel (zwei Entities `obis[0].obis_key` / `obis[0].obis_value`, Root = `obis`):

```json
[
  { "obis_key": "", "obis_value": "" }
]
```

## Hinweis zu Testdaten

Die Werte kommen bewusst **nicht** aus Testdaten (Platzhalter stattdessen) — konsistent mit dem State-Payload-Beispiel, das ebenfalls Leerwerte zeigt. So bleibt der Aufwand gering und das Verhalten einheitlich.

## Tests

- Backend: 432 grün (httppush 28/28 — Default-Parameter ändert Bestandsverhalten nicht).
- Frontend: 18 grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)