### PR TITLE
ci: expose skip_github_release on manual dispatch

### DIFF
--- a/.github/workflows/release-assets-on-dispatch.yml
+++ b/.github/workflows/release-assets-on-dispatch.yml
@@ -25,6 +25,11 @@ on:
         description: 'Version: patch|minor|major or explicit (e.g. 1.2.3). If omitted, read from package.json.'
         required: false
         type: string
+      skip_github_release:
+        description: 'Skip GitHub Release creation (e.g. when re-pushing images for an already-released version).'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds a `skip_github_release` boolean input to the `workflow_dispatch` trigger of the release-assets workflow.

## Why
Release run [29084878988](https://github.com/modbus2mqtt/modbus2mqtt/actions/runs/29084878988) failed at the Docker build step with a transient QEMU SIGILL (exit 132) while emulating arm64 — 0.27.0's GitHub Release exists but its images were never pushed to GHCR. That run can't be retried.

To re-push the images via manual dispatch without minting a **duplicate** release (dispatch tags `v0.27.0` vs. release-please's `modbus2mqtt-v0.27.0`), the dispatch path needs to skip release creation. The `workflow_call` path already had this input; this just mirrors it on `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)