### PR TITLE
fix: live-update HTTP push body preview under zoneless CD

### DIFF
--- a/frontend/src/app/select-slave/select-slave.component.html
+++ b/frontend/src/app/select-slave/select-slave.component.html
@@ -374,7 +374,7 @@
                     }
                   </mat-selection-list>
                   <h2>POST Body Example</h2>
-                  <textarea rows="10" cols="20" readonly>{{ getHttpPushBody(uislave) }}</textarea>
+                  <textarea rows="10" cols="20" readonly>{{ uislave.httpPushBody?.() }}</textarea>
                 </mat-expansion-panel>
               }
               <mat-expansion-panel>

--- a/frontend/src/app/select-slave/select-slave.component.ts
+++ b/frontend/src/app/select-slave/select-slave.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, OnInit, Output, ViewChild } from '@angular/core'
+import { Component, ElementRef, EventEmitter, OnInit, Output, signal, ViewChild, WritableSignal } from '@angular/core'
 import {
   AbstractControl,
   FormBuilder,
@@ -67,6 +67,9 @@ interface IuiSlave {
   slaveForm: FormGroup
   commandEntities?: ImodbusEntity[]
   selectedEntitites?: any
+  // Live preview of the HTTP POST body. A signal (not a template method call) so it re-renders
+  // under zoneless change detection when the push entity selection or root form values change.
+  httpPushBody?: WritableSignal<string | undefined>
   // Set once the per-slave modbus identification has been fetched lazily
   // (on first dropdown open). Keeps the initial page load free of N device reads.
   identSpecsLoaded?: boolean
@@ -241,6 +244,8 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
   //slavesFormArray: FormArray<FormGroup>
   slaveNewForm: FormGroup
   paramsSubscription: Subscription | undefined
+  // Per-uiSlave form valueChanges subscriptions driving the live push-body preview signals.
+  private subscriptions: Subscription[] = []
   errorStateMatcher = new M2mErrorStateMatcher()
 
   bus: IBus | undefined
@@ -467,12 +472,19 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
     // preparedIdentSpecs list. The per-slave modbus identification is fetched lazily on first
     // dropdown open (loadIdentSpecs) to keep the initial page load free of N device reads.
     rc.specsObservable = new ReplaySubject<IidentificationSpecification[]>(1)
+    // Under zoneless CD the HTTP push body preview cannot be a template method call reading live
+    // form values (nothing re-evaluates it). Drive a signal from the form's valueChanges instead so
+    // selecting push entities or editing the root updates the preview immediately.
+    rc.httpPushBody = signal<string | undefined>(this.getHttpPushBody(rc))
+    this.subscriptions.push(fg.valueChanges.subscribe(() => rc.httpPushBody!.set(this.getHttpPushBody(rc))))
     this.addSpecificationToUiSlave(rc, () => {
       rc.selectedEntitites = this.getSelectedEntites(slave)
       this.fillCommandTopics(rc)
       // slave2Form computed this synchronously before the specification was fetched
       // (slaves arrive without an embedded specification) — recompute now that it's here.
       fg.get('discoverEntitiesList')!.setValue(this.buildDiscoverEntityList(slave))
+      // Recompute now that the specification (and thus entity list) is available.
+      rc.httpPushBody!.set(this.getHttpPushBody(rc))
     })
     return rc
   }
@@ -491,6 +503,7 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
   }
   ngOnDestroy(): void {
     this.paramsSubscription && this.paramsSubscription.unsubscribe()
+    this.subscriptions.forEach((s) => s.unsubscribe())
   }
 
   showUnmatched() {

--- a/frontend/src/app/select-slave/select-slave.vitest.spec.ts
+++ b/frontend/src/app/select-slave/select-slave.vitest.spec.ts
@@ -152,6 +152,35 @@ describe('Select Slave tests (vitest)', () => {
     httpMock.match(() => true).forEach((r) => r.flush([]))
   })
 
+  it('http push body preview reacts to entity selection and root (zoneless)', async () => {
+    await mount()
+    const uiSlave = fixture.componentInstance.uiSlaves[0]
+
+    // Deterministic spec so the preview does not depend on async spec loading.
+    uiSlave.slave.specification = { entities: [{ id: 1, mqttname: 'e1' }] } as any
+
+    // A URL is required for a non-empty preview.
+    uiSlave.slaveForm.get('httpPushUrl')!.setValue('https://example.com/push')
+    uiSlave.slaveForm.get('pushEntitiesList')!.setValue([])
+    // No entities selected yet -> empty object. The signal updates from valueChanges alone,
+    // without a change-detection cycle (the regression: under zoneless it never re-rendered).
+    expect(uiSlave.httpPushBody!()).toBe('{}')
+
+    // Selecting the entity must immediately update the signal.
+    uiSlave.slaveForm.get('pushEntitiesList')!.setValue([1])
+    expect(uiSlave.httpPushBody!()).toBe('{"e1":""}')
+
+    // A root that exists narrows the payload to that subtree.
+    uiSlave.slaveForm.get('httpPushRoot')!.setValue('e1')
+    expect(uiSlave.httpPushBody!()).toBe('""')
+
+    // A root that does not exist yields the explanatory placeholder.
+    uiSlave.slaveForm.get('httpPushRoot')!.setValue('nope')
+    expect(uiSlave.httpPushBody!()).toContain('not found')
+
+    httpMock.match(() => true).forEach((r) => r.flush([]))
+  })
+
   it('schedule presets, custom and human-readable description', async () => {
     await mount()
     const c = fixture.componentInstance


### PR DESCRIPTION
## Problem
In the slave HTTP Push section, the **POST Body Example** did not update when selecting push entities or editing the optional **Root**.

## Cause
The app runs with `provideZonelessChangeDetection()`. The preview was a template method call (`{{ getHttpPushBody(uislave) }}`) reading live reactive-form values. Without zone.js, such a binding is not re-evaluated when the form changes, so the textarea stayed stale.

(The *State Payload Example* reads the saved `uiSlave.slave`, so it correctly does not change on live form edits — that is by design, not a bug.)

## Fix
Drive a per-`uiSlave` `WritableSignal` from `slaveForm.valueChanges`. Reading the signal in the template makes the preview re-render immediately when the push entity selection or root changes. Subscriptions are cleaned up in `ngOnDestroy`.

## Tests
Added a regression test asserting the signal updates from `valueChanges` alone (no change-detection cycle) when the push entities and root change. All 4 select-slave vitest cases pass; frontend builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)