### PR TITLE
feat: add {{ pollDate }} URL placeholder for HTTP push

### DIFF
--- a/backend/src/server/httpPush.ts
+++ b/backend/src/server/httpPush.ts
@@ -10,11 +10,11 @@ const log = new Logger('httppush')
 export class HttpPush {
   // Pushes the slave's selected entity values to the configured URL via HTTP POST.
   // Errors are logged but never thrown — a failed push must not stop polling or MQTT.
-  static async pushState(slave: Slave, spec: ImodbusSpecification): Promise<void> {
+  static async pushState(slave: Slave, spec: ImodbusSpecification, pollDate?: Date): Promise<void> {
     const httpPush = slave.getHttpPush()
     if (!slave.hasHttpPush() || !httpPush) return
     try {
-      const url = slave.getResolvedHttpPushUrl(spec.entities)
+      const url = slave.getResolvedHttpPushUrl(spec.entities, pollDate)
       if (url == null) {
         log.log(LogLevelEnum.warn, 'HTTP push skipped: URL placeholder not resolvable url: ' + httpPush.url)
         return

--- a/backend/src/server/mqttpoller.ts
+++ b/backend/src/server/mqttpoller.ts
@@ -112,9 +112,11 @@ export class MqttPoller {
                     tAndP.push({ topic: bs.getStateTopic(), payload: bs.getStatePayload(spec.entities), entityid: 0 })
                     tAndP.push({ topic: bs.getAvailabilityTopic(), payload: 'online', entityid: 0 })
                   }
-                  // HTTP push (runs alongside MQTT, or standalone in HTTP-push-only mode)
+                  // HTTP push (runs alongside MQTT, or standalone in HTTP-push-only mode).
+                  // Pass the poll tick time so the {{ pollDate }} URL placeholder reflects the
+                  // scheduled poll time rather than the (possibly later) push completion instant.
                   if (bs.hasHttpPush()) {
-                    HttpPush.pushState(bs, spec).catch((e) =>
+                    HttpPush.pushState(bs, spec, now).catch((e) =>
                       debug('httpPush failed: ' + (e instanceof Error ? e.message : String(e)))
                     )
                   }

--- a/backend/src/shared/server/Slave.ts
+++ b/backend/src/shared/server/Slave.ts
@@ -266,9 +266,17 @@ export class Slave {
     }
     return JSON.stringify(holder.value)
   }
+  // Formats a poll timestamp as ISO 8601 in UTC with second precision, floored to the poll minute
+  // (the cron fires once per matching minute), e.g. "2026-07-10T08:00:00Z". Backs the {{ pollDate }}
+  // URL placeholder so the endpoint receives the scheduled poll time, not a noisy sub-second instant.
+  static formatPollDate(pollDate?: Date): string {
+    const t = (pollDate ?? new Date()).getTime()
+    return new Date(Math.floor(t / 60000) * 60000).toISOString().replace(/\.\d{3}Z$/, 'Z')
+  }
   // Resolves {{ path }} placeholders in the push URL against ALL entity values (including device
-  // variables such as serialnumber). Returns null when a placeholder cannot be resolved.
-  getResolvedHttpPushUrl(entities: ImodbusEntity[]): string | null {
+  // variables such as serialnumber). The reserved {{ pollDate }} placeholder yields the poll's
+  // timestamp (see formatPollDate). Returns null when a placeholder cannot be resolved.
+  getResolvedHttpPushUrl(entities: ImodbusEntity[], pollDate?: Date): string | null {
     const url = this.slave.httpPush?.url
     if (url == undefined) return null
     if (!url.includes('{{')) return url
@@ -278,7 +286,16 @@ export class Slave {
         Slave.setByPath(holder, Slave.parseMqttPath(e.mqttname), e.mqttValue)
       }
     }
-    return Slave.substituteTemplate(url, holder.value ?? {})
+    // Entity values live at the object root; add the reserved pollDate alongside them. A non-object
+    // holder (e.g. entities forming a top-level array) has no room for it, so fall back to a fresh
+    // context that still resolves {{ pollDate }} — array-rooted entity placeholders are unrealistic
+    // in a URL anyway.
+    const context: Record<string, unknown> =
+      holder.value != undefined && typeof holder.value === 'object' && !Array.isArray(holder.value)
+        ? (holder.value as Record<string, unknown>)
+        : {}
+    context['pollDate'] = Slave.formatPollDate(pollDate)
+    return Slave.substituteTemplate(url, context)
   }
   static compareSlaves(s1: Slave, s2: Slave): number {
     let rc = s1.busid - s2.busid

--- a/backend/src/shared/server/types.ts
+++ b/backend/src/shared/server/types.ts
@@ -31,7 +31,7 @@ export enum PollModes {
   intervallHttpPushNoMqtt = 4, // interval poll + HTTP push, no MQTT state publishing
 }
 export interface IhttpPush {
-  url: string // full target URL, may contain {{ path }} placeholders, e.g. https://heimvio.de/readings/{{ serialnumber }}
+  url: string // full target URL, may contain {{ path }} placeholders, e.g. https://heimvio.de/readings/{{ serialnumber }}; reserved {{ pollDate }} = poll time as ISO 8601 UTC
   patEnc?: string // AES-256-GCM encrypted Bearer PAT (base64), see secureSecret.ts
   pushEntities?: number[] // entity ids to include in the push payload
   root?: string // optional path (mqttname format) selecting a subtree of the push payload, e.g. "orbis"

--- a/backend/tests/server/httppush_test.tsx
+++ b/backend/tests/server/httppush_test.tsx
@@ -250,6 +250,27 @@ describe('Slave http push root + URL templating', () => {
     const slave = new Slave(0, { slaveid: 1, httpPush: { url: 'https://api/static', pushEntities: [1] } }, 'm2m')
     expect(slave.getResolvedHttpPushUrl(orbisEntities)).toBe('https://api/static')
   })
+
+  it('formatPollDate floors to the minute and emits ISO 8601 UTC without milliseconds', () => {
+    expect(Slave.formatPollDate(new Date('2026-07-10T08:00:59.999Z'))).toBe('2026-07-10T08:00:00Z')
+  })
+
+  it('substitutes the reserved {{ pollDate }} with the poll time, url-encoded', () => {
+    const slave = new Slave(0, { slaveid: 1, httpPush: { url: 'https://api/readings?at={{ pollDate }}', pushEntities: [1] } }, 'm2m')
+    const pollDate = new Date('2026-07-10T08:00:03.500Z')
+    expect(slave.getResolvedHttpPushUrl(orbisEntities, pollDate)).toBe('https://api/readings?at=2026-07-10T08%3A00%3A00Z')
+  })
+
+  it('combines an entity placeholder and {{ pollDate }} in one URL', () => {
+    const sn = ent(9, 'serialnumber', '1EMH0011111111', 'text')
+    const slave = new Slave(
+      0,
+      { slaveid: 1, httpPush: { url: 'https://api/readings/{{ serialnumber }}?at={{ pollDate }}', pushEntities: [1] } },
+      'm2m'
+    )
+    const pollDate = new Date('2026-07-10T08:00:00.000Z')
+    expect(slave.getResolvedHttpPushUrl([sn], pollDate)).toBe('https://api/readings/1EMH0011111111?at=2026-07-10T08%3A00%3A00Z')
+  })
 })
 
 // Exercises exactly what the backend poll process runs: mqttpoller calls HttpPush.pushState(slave, spec)
@@ -308,6 +329,19 @@ describe('HttpPush.pushState (poll process)', () => {
       { orbis_key: '0-1:1.8.0', orbis_value: 100 },
       { orbis_key: '0-2:1.8.0', orbis_value: 200 },
     ])
+  })
+
+  it('passes the poll time into the {{ pollDate }} URL placeholder', async () => {
+    fetchMock = jest.fn(async () => ({ ok: true, status: 200, statusText: 'OK' }) as any)
+    globalThis.fetch = fetchMock as any
+    const mk = (id: number, mqttname: string, v: unknown): ImodbusEntity =>
+      ({ id, mqttname, converter: 'number', readonly: true, mqttValue: v }) as unknown as ImodbusEntity
+    const spec = { entities: [mk(1, 'power', 5)] } as unknown as ImodbusSpecification
+    const slave = new Slave(0, { slaveid: 1, httpPush: { url: 'https://api/r?at={{ pollDate }}', pushEntities: [1] } }, 'm2m')
+    await HttpPush.pushState(slave, spec, new Date('2026-07-10T08:00:03.500Z'))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [calledUrl] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(calledUrl).toBe('https://api/r?at=2026-07-10T08%3A00%3A00Z')
   })
 
   it('skips the push (no fetch) when the root path is missing', async () => {

--- a/frontend/src/app/select-slave/select-slave.component.ts
+++ b/frontend/src/app/select-slave/select-slave.component.ts
@@ -112,7 +112,9 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
   // Literal strings (contain {{ }}) kept out of the template to avoid Angular interpolation.
   readonly httpPushUrlPlaceholder = 'https://heimvio.de/readings/{{ serialnumber }}'
   readonly httpPushUrlTooltip =
-    'Full target URL. Use {{ path }} placeholders to insert entity values, e.g. {{ serialnumber }}.'
+    'Full target URL. Use {{ path }} placeholders to insert entity values, e.g. {{ serialnumber }}.\n' +
+    'The reserved {{ pollDate }} inserts the poll time as ISO 8601 UTC, e.g. 2026-07-10T08:00:00Z ' +
+    '(e.g. ...?at={{ pollDate }}).'
   readonly pollScheduleTooltip =
     'Optional Unix cron expression. When set it overrides Poll Interval.\n' +
     '5 fields: minute hour day-of-month month day-of-week.\n' +


### PR DESCRIPTION
## Motivation
The HTTP push endpoint (e.g. heimvio) needs the **poll time** in the request, as a query parameter like `?at=…`. It must be the scheduled poll time (e.g. 10:00), not an arbitrary current timestamp.

## What
Adds a reserved `{{ pollDate }}` placeholder usable anywhere in the push URL:

```
https://heimvio.de/readings/{{ serialnumber }}?at={{ pollDate }}
-> https://heimvio.de/readings/1EMH0011111111?at=2026-07-10T08%3A00%3A00Z
```

- Resolves to the poll timestamp as **ISO 8601 UTC**, second precision, floored to the poll minute (the cron fires once per matching minute) — e.g. `2026-07-10T08:00:00Z`.
- The poller passes its tick time (`now`) into `HttpPush.pushState(slave, spec, now)`, so the value is the scheduled poll time, not the later push-completion instant. (We rely on the poll being triggered on time, per discussion.)
- `Slave.formatPollDate()` formats it; `getResolvedHttpPushUrl()` injects it into the template context next to entity values.

## Docs
URL tooltip and `IhttpPush.url` comment mention `{{ pollDate }}`.

## Tests
4 new backend tests (formatPollDate flooring, `{{ pollDate }}` substitution + url-encoding, combined with an entity placeholder, and end-to-end through `pushState`). All 32 httppush tests pass; backend + frontend build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)