### PR TITLE
feat: add {{ slaveName }} URL placeholder for HTTP push

### DIFF
--- a/backend/src/shared/server/Slave.ts
+++ b/backend/src/shared/server/Slave.ts
@@ -275,7 +275,9 @@ export class Slave {
   }
   // Resolves {{ path }} placeholders in the push URL against ALL entity values (including device
   // variables such as serialnumber). The reserved {{ pollDate }} placeholder yields the poll's
-  // timestamp (see formatPollDate). Returns null when a placeholder cannot be resolved.
+  // timestamp (see formatPollDate), {{ slaveName }} the slave's configured name. All substituted
+  // values are URL-encoded. Returns null when a placeholder cannot be resolved (e.g. {{ slaveName }}
+  // on a slave without a name), which makes the caller skip the push.
   getResolvedHttpPushUrl(entities: ImodbusEntity[], pollDate?: Date): string | null {
     const url = this.slave.httpPush?.url
     if (url == undefined) return null
@@ -286,15 +288,16 @@ export class Slave {
         Slave.setByPath(holder, Slave.parseMqttPath(e.mqttname), e.mqttValue)
       }
     }
-    // Entity values live at the object root; add the reserved pollDate alongside them. A non-object
-    // holder (e.g. entities forming a top-level array) has no room for it, so fall back to a fresh
-    // context that still resolves {{ pollDate }} — array-rooted entity placeholders are unrealistic
-    // in a URL anyway.
+    // Entity values live at the object root; add the reserved variables alongside them. A non-object
+    // holder (e.g. entities forming a top-level array) has no room for them, so fall back to a fresh
+    // context that still resolves the reserved names — array-rooted entity placeholders are
+    // unrealistic in a URL anyway.
     const context: Record<string, unknown> =
       holder.value != undefined && typeof holder.value === 'object' && !Array.isArray(holder.value)
         ? (holder.value as Record<string, unknown>)
         : {}
     context['pollDate'] = Slave.formatPollDate(pollDate)
+    if (this.slave.name != undefined && this.slave.name.length > 0) context['slaveName'] = this.slave.name
     return Slave.substituteTemplate(url, context)
   }
   static compareSlaves(s1: Slave, s2: Slave): number {

--- a/backend/src/shared/server/types.ts
+++ b/backend/src/shared/server/types.ts
@@ -31,7 +31,7 @@ export enum PollModes {
   intervallHttpPushNoMqtt = 4, // interval poll + HTTP push, no MQTT state publishing
 }
 export interface IhttpPush {
-  url: string // full target URL, may contain {{ path }} placeholders, e.g. https://heimvio.de/readings/{{ serialnumber }}; reserved {{ pollDate }} = poll time as ISO 8601 UTC
+  url: string // full target URL, may contain {{ path }} placeholders, e.g. https://heimvio.de/readings/{{ serialnumber }}; reserved: {{ pollDate }} = poll time as ISO 8601 UTC, {{ slaveName }} = the slave's name
   patEnc?: string // AES-256-GCM encrypted Bearer PAT (base64), see secureSecret.ts
   pushEntities?: number[] // entity ids to include in the push payload
   root?: string // optional path (mqttname format) selecting a subtree of the push payload, e.g. "orbis"

--- a/backend/tests/server/httppush_test.tsx
+++ b/backend/tests/server/httppush_test.tsx
@@ -271,6 +271,35 @@ describe('Slave http push root + URL templating', () => {
     const pollDate = new Date('2026-07-10T08:00:00.000Z')
     expect(slave.getResolvedHttpPushUrl([sn], pollDate)).toBe('https://api/readings/1EMH0011111111?at=2026-07-10T08%3A00%3A00Z')
   })
+
+  it('substitutes the reserved {{ slaveName }} with the slave name, url-encoded', () => {
+    const slave = new Slave(
+      0,
+      { slaveid: 1, name: 'Zähler Küche/EG', httpPush: { url: 'https://api/readings?meter={{ slaveName }}', pushEntities: [1] } },
+      'm2m'
+    )
+    expect(slave.getResolvedHttpPushUrl(orbisEntities)).toBe('https://api/readings?meter=Z%C3%A4hler%20K%C3%BCche%2FEG')
+  })
+
+  it('returns null for {{ slaveName }} when the slave has no name', () => {
+    const slave = new Slave(0, { slaveid: 1, httpPush: { url: 'https://api/readings?meter={{ slaveName }}', pushEntities: [1] } }, 'm2m')
+    expect(slave.getResolvedHttpPushUrl(orbisEntities)).toBeNull()
+  })
+
+  it('combines {{ slaveName }}, an entity placeholder and {{ pollDate }} in one URL', () => {
+    const sn = ent(9, 'serialnumber', '1EMH0011111111', 'text')
+    const slave = new Slave(
+      0,
+      {
+        slaveid: 1,
+        name: 'Meter 1',
+        httpPush: { url: 'https://api/{{ slaveName }}/{{ serialnumber }}?at={{ pollDate }}', pushEntities: [1] },
+      },
+      'm2m'
+    )
+    const pollDate = new Date('2026-07-10T08:00:00.000Z')
+    expect(slave.getResolvedHttpPushUrl([sn], pollDate)).toBe('https://api/Meter%201/1EMH0011111111?at=2026-07-10T08%3A00%3A00Z')
+  })
 })
 
 // Exercises exactly what the backend poll process runs: mqttpoller calls HttpPush.pushState(slave, spec)

--- a/frontend/src/app/select-slave/select-slave.component.ts
+++ b/frontend/src/app/select-slave/select-slave.component.ts
@@ -117,7 +117,9 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
   readonly httpPushUrlTooltip =
     'Full target URL. Use {{ path }} placeholders to insert entity values, e.g. {{ serialnumber }}.\n' +
     'The reserved {{ pollDate }} inserts the poll time as ISO 8601 UTC, e.g. 2026-07-10T08:00:00Z ' +
-    '(e.g. ...?at={{ pollDate }}).'
+    '(e.g. ...?at={{ pollDate }}).\n' +
+    'The reserved {{ slaveName }} inserts the Slave Name from Slave Settings ' +
+    '(e.g. ...?meter={{ slaveName }}). All values are URL-encoded.'
   readonly pollScheduleTooltip =
     'Optional Unix cron expression. When set it overrides Poll Interval.\n' +
     '5 fields: minute hour day-of-month month day-of-week.\n' +


### PR DESCRIPTION
Adds a second reserved template variable for the HTTP push URL (after `{{ pollDate }}` in #279), resolving to the **Slave Name** from Slave Settings. This lets all meters pushing to the same endpoint share one identical push configuration:

```
https://heimvio.de/readings/{{ slaveName }}?at={{ pollDate }}
```

- `getResolvedHttpPushUrl` adds `slaveName` to the substitution context alongside `pollDate` and the entity values.
- The value is URL-encoded by the existing `substituteTemplate`, so umlauts, spaces and slashes in a slave name are safe (`Zähler Küche/EG` → `Z%C3%A4hler%20K%C3%BCche%2FEG`).
- `slaveName` is only added when the slave has a non-empty name. An unnamed slave using the placeholder therefore resolves to `null` and the push is skipped — the same behaviour as for any other unresolvable placeholder.
- The URL field's tooltip in the slave HTTP Push section documents the new variable.

## Tests

`backend/tests/server/httppush_test.tsx` — 35 tests, all green. Three new cases: URL-encoding of a name with umlauts and a slash, the `null` result for a slave without a name, and `{{ slaveName }}` combined with an entity placeholder and `{{ pollDate }}` in one URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)