### PR TITLE
fix: honour swapWords/swapBytes and keep the last value on a failed poll

### DIFF
--- a/backend/src/server/modbusRTUworker.ts
+++ b/backend/src/server/modbusRTUworker.ts
@@ -284,6 +284,19 @@ export class ModbusRTUWorker extends ModbusWorker {
       }
   }
 
+  // The last successfully read values of the entry's address range, or undefined as soon as one
+  // register of it has no cached value (a value the cache dropped as too old, or one never read).
+  private getCachedData(current: IQueueEntry): number[] | undefined {
+    const table = this.getCachedMap(current)
+    if (table == undefined) return undefined
+    const rc: number[] = []
+    for (let idx = 0; idx < (current.address.length ? current.address.length : 1); idx++) {
+      const cached = table.get(current.address.address + idx)
+      if (cached == undefined || cached.data == undefined || cached.data.length == 0) return undefined
+      rc.push(cached.data[0])
+    }
+    return rc
+  }
   private isInCacheMap(current: IQueueEntry): Map<number, IModbusResultOrError> | undefined {
     if (current.options && current.options.useCache) {
       const mp = this.getCachedMap(current)
@@ -344,8 +357,17 @@ export class ModbusRTUWorker extends ModbusWorker {
               .catch((e) => {
                 this.debugMessage(current, ' failed permanently')
                 this.updateCacheError(current, e)
-                debug('Success: ' + current.address.address + 'e: ' + e.message)
-                current.onError(current, e)
+                debug('Failed: ' + current.address.address + ' e: ' + e.message)
+                // A failed poll read used to yield no data at all, so the entity was published as an
+                // empty value and Home Assistant flipped it to "unknown" until the next successful
+                // poll (issue #229). The cache still holds the last good value (updateCacheError keeps
+                // it for errorTimeout), so keep publishing that instead of a hole. The failure is not
+                // swallowed: it was recorded in the slave's Status & Errors before we got here.
+                const lastKnown = current.options.task == ModbusTasks.poll ? this.getCachedData(current) : undefined
+                if (lastKnown != undefined) {
+                  this.debugMessage(current, ' serving the last known value from the cache')
+                  current.onResolve(current, lastKnown)
+                } else current.onError(current, e)
                 resolve()
               })
           })
@@ -414,7 +436,14 @@ export class ModbusRTUWorker extends ModbusWorker {
   private processOneEntry(): Promise<void> | undefined {
     const current = this.queue.dequeue()
     if (current) {
-      debug('processOneEntry: ql:' + this.queue.getLength() + ' address: ' + current?.address.address + ' len: ' + (current?.address.length ? current.address.length : 1))
+      debug(
+        'processOneEntry: ql:' +
+          this.queue.getLength() +
+          ' address: ' +
+          current?.address.address +
+          ' len: ' +
+          (current?.address.length ? current.address.length : 1)
+      )
       const dt = new Date()
       if (this.cache.get(current.slaveId) == undefined) this.cache.set(current.slaveId, this.createEmptyIModbusValues())
       const cacheEntry = this.cache.get(current.slaveId)

--- a/backend/src/specification/numberConverter.ts
+++ b/backend/src/specification/numberConverter.ts
@@ -8,6 +8,28 @@ export class NumberConverter extends Converter {
     if (!component) component = 'number'
     super(component)
   }
+  // Modbus itself only defines the byte order inside a register (big endian). How a device spreads a
+  // 32 bit value over two registers is not standardized: some send the high word first, others the low
+  // word first (e.g. Sungrow), and a few even swap the bytes inside a register. swapWords/swapBytes let
+  // a specification describe that, so the raw registers are reordered into the canonical
+  // "high word first, big endian bytes" layout before they are decoded.
+  private static isNumberFormat32(numberFormat: EnumNumberFormat): boolean {
+    return [EnumNumberFormat.float32, EnumNumberFormat.signedInt32, EnumNumberFormat.unsignedInt32].includes(numberFormat)
+  }
+  private static swapBytesInRegister(register: number): number {
+    return ((register & 0xff) << 8) | ((register >> 8) & 0xff)
+  }
+  // Applies the entity's swap settings. Used in both directions: swapping is its own inverse.
+  private static applySwaps(registers: number[], entity: Ientity, numberFormat: EnumNumberFormat): number[] {
+    const params = entity.converterParameters as Inumber | undefined
+    let rc = registers
+    // Byte order inside each register.
+    if (params?.swapBytes === true) rc = rc.map((r) => NumberConverter.swapBytesInRegister(r))
+    // Word order. Only a 32 bit value has two words to swap.
+    if (params?.swapWords === true && NumberConverter.isNumberFormat32(numberFormat) && rc.length >= 2)
+      rc = [rc[1], rc[0], ...rc.slice(2)]
+    return rc
+  }
   modbus2mqtt(spec: Ispecification, entityid: number, value: number[]): number | string {
     const entity = spec.entities.find((e) => e.id == entityid)
     if (entity) {
@@ -15,30 +37,34 @@ export class NumberConverter extends Converter {
 
       const numberFormat =
         entity.converterParameters != undefined && (entity.converterParameters as Inumber).numberFormat != undefined
-          ? (entity.converterParameters as Inumber).numberFormat
+          ? (entity.converterParameters as Inumber).numberFormat!
           : EnumNumberFormat.default
 
-      let v = value[0]
+      if (NumberConverter.isNumberFormat32(numberFormat) && value.length < 2)
+        throw new Error('NumberConverter.modbus2mqtt: a 32 bit number needs two registers, got ' + value.length)
+
+      const registers = NumberConverter.applySwaps(value, entity, numberFormat)
+      let v = registers[0]
       const buffer16 = Buffer.allocUnsafe(4)
       const buffer32 = Buffer.allocUnsafe(4)
       switch (numberFormat) {
         case EnumNumberFormat.float32:
-          buffer32.writeUInt16BE(value[0])
-          buffer32.writeUInt16BE(value[1], 2)
+          buffer32.writeUInt16BE(registers[0])
+          buffer32.writeUInt16BE(registers[1], 2)
           v = buffer32.readFloatBE()
           break
         case EnumNumberFormat.signedInt16:
-          buffer16.writeUInt16BE(value[0])
+          buffer16.writeUInt16BE(registers[0])
           v = buffer16.readInt16BE()
           break
         case EnumNumberFormat.unsignedInt32:
-          buffer32.writeUInt16BE(value[0])
-          buffer32.writeUInt16BE(value[1], 2)
+          buffer32.writeUInt16BE(registers[0])
+          buffer32.writeUInt16BE(registers[1], 2)
           v = buffer32.readUint32BE()
           break
         case EnumNumberFormat.signedInt32:
-          buffer32.writeUInt16BE(value[0])
-          buffer32.writeUInt16BE(value[1], 2)
+          buffer32.writeUInt16BE(registers[0])
+          buffer32.writeUInt16BE(registers[1], 2)
           v = buffer32.readInt32BE()
           break
       }
@@ -61,27 +87,30 @@ export class NumberConverter extends Converter {
     if (entity) {
       const numberFormat =
         entity.converterParameters != undefined && (entity.converterParameters as Inumber).numberFormat != undefined
-          ? (entity.converterParameters as Inumber).numberFormat
+          ? (entity.converterParameters as Inumber).numberFormat!
           : EnumNumberFormat.default
       const buf: Buffer = Buffer.allocUnsafe(4)
 
       value = ((value as number) - offset) / multiplier
       const v = value
+      // The canonical registers are built first; the swaps then bring them into the device's own
+      // layout - the exact inverse of modbus2mqtt, because swapping is its own inverse.
+      const swap = (registers: number[]): number[] => NumberConverter.applySwaps(registers, entity, numberFormat)
       switch (numberFormat) {
         case EnumNumberFormat.float32:
           buf.writeFloatBE(v)
-          return [buf.readUInt16BE(0), buf.readUInt16BE(2)]
+          return swap([buf.readUInt16BE(0), buf.readUInt16BE(2)])
         case EnumNumberFormat.signedInt16:
           buf.writeInt16BE(v)
-          return [buf.readUInt16BE()]
+          return swap([buf.readUInt16BE()])
         case EnumNumberFormat.unsignedInt32:
           buf.writeUint32BE(v)
-          return [buf.readUInt16BE(0), buf.readUInt16BE(2)]
+          return swap([buf.readUInt16BE(0), buf.readUInt16BE(2)])
         case EnumNumberFormat.signedInt32:
           buf.writeInt32BE(v)
-          return [buf.readUInt16BE(0), buf.readUInt16BE(2)]
+          return swap([buf.readUInt16BE(0), buf.readUInt16BE(2)])
         default:
-          return [v]
+          return swap([v])
       }
     }
     throw new Error('entityid not found in entities')

--- a/backend/src/specification/textConverter.ts
+++ b/backend/src/specification/textConverter.ts
@@ -20,11 +20,19 @@ export class TextConverter extends Converter {
       return (entity.converterParameters as Ivalue).value
     const cvP = entity?.converterParameters as Itext
     const buffer = Buffer.allocUnsafe(cvP.stringlength * 2)
-    for (let idx = 0; idx < (cvP.stringlength + 1) / 2; idx++) buffer.writeUInt16BE(value[idx], idx * 2)
+    // Some devices put the two characters of a register in the opposite order ("OMDBSU" instead of
+    // "MODBUS"). swapBytes turns the register around before the text is read out of it.
+    for (let idx = 0; idx < (cvP.stringlength + 1) / 2; idx++)
+      buffer.writeUInt16BE(TextConverter.swapBytesIf(value[idx], cvP.swapBytes === true), idx * 2)
 
     const idx = buffer.findIndex((v) => v == 0)
     if (idx >= 0) return buffer.subarray(0, idx).toString()
     return buffer.toString()
+  }
+  // Swapping is its own inverse, so both directions use it.
+  private static swapBytesIf(register: number, swap: boolean): number {
+    if (!swap) return register
+    return ((register & 0xff) << 8) | ((register >> 8) & 0xff)
   }
   override getModbusRegisterTypes(): ModbusRegisterType[] {
     return [ModbusRegisterType.HoldingRegister, ModbusRegisterType.AnalogInputs]
@@ -32,10 +40,11 @@ export class TextConverter extends Converter {
   override mqtt2modbus(spec: Ispecification, entityid: number, _value: string): number[] {
     const entity = spec.entities.find((e) => e.id == entityid)
     if (!entity) throw new Error('entity not found in entities')
+    const swapBytes = (entity.converterParameters as Itext | undefined)?.swapBytes === true
     const rc: number[] = []
     for (let i = 0; i < _value.length; i += 2) {
-      if (i + 1 < _value.length) rc.push((_value.charCodeAt(i) << 8) | _value.charCodeAt(i + 1))
-      else rc.push(_value.charCodeAt(i) << 8)
+      const register = i + 1 < _value.length ? (_value.charCodeAt(i) << 8) | _value.charCodeAt(i + 1) : _value.charCodeAt(i) << 8
+      rc.push(TextConverter.swapBytesIf(register, swapBytes))
     }
     return rc
   }

--- a/backend/tests/server/ModbusRTUWorker_test.tsx
+++ b/backend/tests/server/ModbusRTUWorker_test.tsx
@@ -359,3 +359,80 @@ describe('ModbusRTUWorker write', () => {
     await finished
   })
 })
+
+// Issue #229: a failing poll read produced no data, the entity was published as an empty value and
+// Home Assistant flipped it to "unknown" until the next successful poll - the values kept toggling.
+// The cache still holds the last successfully read value, so a failing poll now serves that.
+class FlakyApi implements IModbusAPI {
+  fail = false
+  constructor(private cacheId: string) {}
+  getCacheId(): string {
+    return this.cacheId
+  }
+  reconnectRTU(): Promise<void> {
+    return Promise.resolve()
+  }
+  private read = (_slaveid: number, _address: number, _length: number) => {
+    if (this.fail) {
+      const e = new Error('Error') as Error & { errno?: string }
+      e.errno = 'ETIMEDOUT'
+      return Promise.reject(e)
+    }
+    return Promise.resolve({ data: [42], duration: 1 })
+  }
+  readHoldingRegisters = this.read
+  readCoils = this.read
+  readDiscreteInputs = this.read
+  readInputRegisters = this.read
+  writeHoldingRegisters = () => Promise.resolve()
+  writeCoils = () => Promise.resolve()
+}
+
+function poll(worker: ModbusRTUWorker, queue: ModbusRTUQueue, task: ModbusTasks): Promise<number[] | Error> {
+  return new Promise<number[] | Error>((resolve) => {
+    queue.enqueue(
+      1,
+      { registerType: ModbusRegisterType.HoldingRegister, address: 7 },
+      (_qe, data) => resolve(data as number[]),
+      (_qe, e) => resolve(e as Error),
+      { task, errorHandling: {} }
+    )
+    worker.run()
+  })
+}
+
+describe('failing reads keep the last known value (issue #229)', () => {
+  it('serves the cached value when a poll read fails', async () => {
+    const api = new FlakyApi('flaky-poll')
+    const queue = new ModbusRTUQueue()
+    const worker = new ModbusRTUWorker(api, queue)
+
+    expect(await poll(worker, queue, ModbusTasks.poll)).toEqual([42])
+
+    // the device stops answering: the poll must still deliver the last known value, not a hole
+    api.fail = true
+    expect(await poll(worker, queue, ModbusTasks.poll)).toEqual([42])
+  })
+
+  it('does not fake a value for a task other than the poll', async () => {
+    const api = new FlakyApi('flaky-spec')
+    const queue = new ModbusRTUQueue()
+    const worker = new ModbusRTUWorker(api, queue)
+
+    expect(await poll(worker, queue, ModbusTasks.specification)).toEqual([42])
+
+    // device detection and specification reads must see the failure - a stale value would
+    // silently identify the wrong device
+    api.fail = true
+    expect(await poll(worker, queue, ModbusTasks.specification)).toBeInstanceOf(Error)
+  })
+
+  it('reports the failure when nothing was ever read successfully', async () => {
+    const api = new FlakyApi('flaky-cold')
+    api.fail = true
+    const queue = new ModbusRTUQueue()
+    const worker = new ModbusRTUWorker(api, queue)
+
+    expect(await poll(worker, queue, ModbusTasks.poll)).toBeInstanceOf(Error)
+  })
+})

--- a/backend/tests/specification/convertermap_test.tsx
+++ b/backend/tests/specification/convertermap_test.tsx
@@ -387,3 +387,111 @@ it('test button converter', () => {
   modbusValue = converter?.mqtt2modbus(spec, entity.id, 'OFF')
   expect(modbusValue![0]).toBe(0)
 })
+
+// Issue #246: swapWords/swapBytes were stored in the specification and offered in the UI, but no
+// converter ever read them. A Sungrow inverter sends the low word of a 32 bit value first, so
+// "Total DC power" of 177 W arrived as 177 << 16 = 11599872 and the Swap Word toggle did nothing.
+function numberEntity(converterParameters: object): Ientity {
+  return {
+    id: 1,
+    mqttname: 'mqtt',
+    converter: 'number' as Converters,
+    registerType: ModbusRegisterType.HoldingRegister,
+    readonly: false,
+    modbusAddress: 5016,
+    converterParameters,
+  } as Ientity
+}
+function decode(entity: Ientity, registers: number[]): number {
+  spec.entities = [entity]
+  return ConverterMap.getConverter(entity)!.modbus2mqtt(spec, entity.id, registers) as number
+}
+
+it('decodes a 32 bit number, high word first, when swapWords is off', () => {
+  const entity = numberEntity({ multiplier: 1, offset: 0, numberFormat: EnumNumberFormat.unsignedInt32 })
+  expect(decode(entity, [0, 177])).toBe(177)
+  expect(decode(entity, [177, 0])).toBe(11599872) // 177 << 16 - the value the issue reports
+})
+
+it('decodes a 32 bit number, low word first, when swapWords is on', () => {
+  const entity = numberEntity({
+    multiplier: 1,
+    offset: 0,
+    numberFormat: EnumNumberFormat.unsignedInt32,
+    swapWords: true,
+  })
+  // the raw registers from the issue: 5016 = 177, 5017 = 0
+  expect(decode(entity, [177, 0])).toBe(177)
+  expect(decode(entity, [0, 1])).toBe(65536)
+})
+
+it('swapWords works for signedInt32 and float32 too', () => {
+  const signed = numberEntity({ multiplier: 1, offset: 0, numberFormat: EnumNumberFormat.signedInt32, swapWords: true })
+  expect(decode(signed, [0xffff, 0xffff])).toBe(-1)
+  // -2 = 0xfffffffe: high word 0xffff, low word 0xfffe -> device sends the low word first
+  expect(decode(signed, [0xfffe, 0xffff])).toBe(-2)
+
+  const float = numberEntity({ multiplier: 1, offset: 0, numberFormat: EnumNumberFormat.float32, swapWords: true })
+  // 1.5f = 0x3fc00000
+  expect(decode(float, [0x0000, 0x3fc0])).toBe(1.5)
+})
+
+it('swapBytes turns the bytes inside every register around', () => {
+  const entity = numberEntity({ multiplier: 1, offset: 0, swapBytes: true })
+  expect(decode(entity, [0x3412])).toBe(0x1234)
+
+  const both = numberEntity({
+    multiplier: 1,
+    offset: 0,
+    numberFormat: EnumNumberFormat.unsignedInt32,
+    swapWords: true,
+    swapBytes: true,
+  })
+  // canonical 0x12345678 arriving as low word first with swapped bytes: [0x7856, 0x3412]
+  expect(decode(both, [0x7856, 0x3412])).toBe(0x12345678)
+})
+
+it('swapWords is ignored for a 16 bit number', () => {
+  const entity = numberEntity({ multiplier: 1, offset: 0, numberFormat: EnumNumberFormat.signedInt16, swapWords: true })
+  expect(decode(entity, [0xffff])).toBe(-1)
+})
+
+it('rejects a 32 bit number that was read with a single register', () => {
+  const entity = numberEntity({ multiplier: 1, offset: 0, numberFormat: EnumNumberFormat.unsignedInt32 })
+  spec.entities = [entity]
+  expect(() => ConverterMap.getConverter(entity)!.modbus2mqtt(spec, entity.id, [177])).toThrow('two registers')
+})
+
+it('writes the registers back in the layout the device sent them in', () => {
+  const entity = numberEntity({
+    multiplier: 1,
+    offset: 0,
+    numberFormat: EnumNumberFormat.unsignedInt32,
+    swapWords: true,
+    swapBytes: true,
+  })
+  spec.entities = [entity]
+  const converter = ConverterMap.getConverter(entity)!
+  const registers = converter.mqtt2modbus(spec, entity.id, 0x12345678)
+  expect(registers).toEqual([0x7856, 0x3412])
+  // round trip: what we write is what we would read back
+  expect(converter.modbus2mqtt(spec, entity.id, registers)).toBe(0x12345678)
+})
+
+it('text swapBytes turns the characters of a register around', () => {
+  const entity = {
+    id: 1,
+    mqttname: 'serial',
+    converter: 'text' as Converters,
+    registerType: ModbusRegisterType.HoldingRegister,
+    readonly: false,
+    modbusAddress: 1,
+    converterParameters: { stringlength: 6, swapBytes: true },
+  } as Ientity
+  spec.entities = [entity]
+  const converter = ConverterMap.getConverter(entity)!
+  // "MODBUS" sent byte swapped per register: "OM", "BD", "SU"
+  const registers = [0x4f4d, 0x4244, 0x5355]
+  expect(converter.modbus2mqtt(spec, entity.id, registers)).toBe('MODBUS')
+  expect(converter.mqtt2modbus(spec, entity.id, 'MODBUS')).toEqual(registers)
+})


### PR DESCRIPTION
Two reported problems, both about the gap between what the device sends and what modbus2mqtt publishes.

## swapWords / swapBytes did nothing — closes #246

`swapWords` and `swapBytes` are part of `Inumber`/`Itext` and the entity form writes them into the specification, but **no converter ever read them**. `NumberConverter` always assembled a 32 bit value high word first.

A Sungrow SHx sends the low word first, so 177 W of DC power (registers `177, 0`) decoded to `177 << 16 = 11599872` — exactly the number in the issue — and toggling *Swap Word* changed nothing. (The reporter's second observation, 11927552, is `182 × 65536`: the value had only moved because the actual power had.)

- `applySwaps()` reorders the raw registers into the canonical layout (high word first, big endian bytes) before decoding: `swapBytes` turns the bytes around inside each register, `swapWords` swaps the two registers of a 32 bit value.
- The same function runs on the way out (`mqtt2modbus`) — swapping is its own inverse. Without it a command would have written swapped registers into the device.
- `swapBytes` now applies to text entities as well (byte swapped serial numbers).
- A 32 bit number read with a single register now raises a clear error instead of decoding garbage.

## Values toggling between the reading and "unknown" — closes #229

A failing poll read left its registers out of the result, `populateEntitiesForSpecification` published the entity as an empty value, and Home Assistant flipped it to `unknown` until the next successful poll. That is the toggling in the issue, and it hits the static diagnostic entities (serial number) first because they are long multi-register reads.

The modbus cache already keeps the last successfully read value — `updateCacheError()` deliberately preserves it for `errorTimeout` (5 h). The poll simply never asked. It now serves that value when a read fails permanently.

Deliberately narrow:
- **Only the poll.** Device detection and specification reads still see the failure; a stale value there would identify the wrong device.
- **The failure is not swallowed.** It is recorded in the slave's Status & Errors (#288) before the fallback runs, so it stays visible and diagnosable.
- After 5 h without a successful read the cache entry expires and the entity falls back to the error path.

## Tests

478 backend tests green. New coverage: the raw registers from #246 (with and without swap, for `unsignedInt32`, `signedInt32`, `float32`, the 16 bit no-op, both swaps combined, and a write round trip), text `swapBytes`, and the cache fallback (poll keeps the value / specification task still fails / a cold cache still reports the error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)