### PR TITLE
feat: configurable serial framing (data bits, parity, stop bits)

### DIFF
--- a/backend/src/server/modbusAPI.ts
+++ b/backend/src/server/modbusAPI.ts
@@ -6,6 +6,9 @@ import {
   ITCPConnection,
   IModbusConnection,
   ImodbusStatusForSlave,
+  DEFAULT_SERIAL_DATABITS,
+  DEFAULT_SERIAL_PARITY,
+  DEFAULT_SERIAL_STOPBITS,
 } from '../shared/server/index.js'
 import { ImodbusValues, Logger, LogLevelEnum } from '../specification/index.js'
 import { ModbusRegisterType } from '../shared/specification/index.js'
@@ -78,8 +81,7 @@ export class ModbusAPI implements IModbusAPI, IconsumerModbusAPI {
         options.maxRegistersPerRequest ?? this.modbusConfiguration.getMaxRegistersPerRequestBySlaveId(slaveId),
     }
 
-    if (this.modbusClient && this.modbusClient.isOpen)
-      return this.modbusRTUprocessor.execute(slaveId, addresses, resolvedOptions)
+    if (this.modbusClient && this.modbusClient.isOpen) return this.modbusRTUprocessor.execute(slaveId, addresses, resolvedOptions)
     else
       return new Promise<ImodbusValues>((resolve, reject) => {
         this.initialConnect()
@@ -291,10 +293,18 @@ export class ModbusAPI implements IModbusAPI, IconsumerModbusAPI {
     if (this.modbusClient == undefined) this.modbusClient = new ModbusRTU()
     if (this.modbusClient.isOpen) return Promise.resolve()
 
-    const port = (this.modbusConfiguration.getModbusConnection() as IRTUConnection).serialport
-    const baudrate = (this.modbusConfiguration.getModbusConnection() as IRTUConnection).baudrate
+    const rtu = this.modbusConfiguration.getModbusConnection() as IRTUConnection
+    const port = rtu.serialport
+    const baudrate = rtu.baudrate
     if (port && baudrate) {
-      return this.modbusClient.connectRTUBuffered(port, { baudRate: baudrate })
+      // Framing beyond the baud rate was hard wired to 8N1 before. A device that speaks 8E1 - which
+      // the Modbus specification actually asks for - answered with nothing but timeouts and CRC errors.
+      return this.modbusClient.connectRTUBuffered(port, {
+        baudRate: baudrate,
+        dataBits: (rtu.dataBits ?? DEFAULT_SERIAL_DATABITS) as 7 | 8,
+        parity: rtu.parity ?? DEFAULT_SERIAL_PARITY,
+        stopBits: (rtu.stopBits ?? DEFAULT_SERIAL_STOPBITS) as 1 | 2,
+      })
     } else {
       const host = (this.modbusConfiguration.getModbusConnection() as ITCPConnection).host
       const tcpport = (this.modbusConfiguration.getModbusConnection() as ITCPConnection).port

--- a/backend/src/shared/server/types.ts
+++ b/backend/src/shared/server/types.ts
@@ -56,11 +56,21 @@ export interface ImqttClient {
   log?: (...args: unknown[]) => void
 }
 
+// Modbus RTU framing. The Modbus specification asks for even parity (8E1), but most devices ship
+// with 8N1, so that stays the default when nothing is configured. Devices that insist on 8E1 or 8N2
+// could not be reached at all before these settings existed.
+export type SerialParity = 'none' | 'even' | 'odd'
+export const DEFAULT_SERIAL_DATABITS = 8
+export const DEFAULT_SERIAL_PARITY: SerialParity = 'none'
+export const DEFAULT_SERIAL_STOPBITS = 1
 export interface IRTUConnection {
   serialport: string
   baudrate: number
   timeout: number
   tcpBridgePort?: number
+  dataBits?: number // 7 or 8, default 8
+  parity?: SerialParity // default none
+  stopBits?: number // 1 or 2, default 1
 }
 export interface ITCPConnection {
   host: string
@@ -107,10 +117,19 @@ export interface IBus {
   connectionData: IModbusConnection
   slaves: Islave[]
 }
+// The framing as the modbus world writes it: 8N1, 8E1, 8N2 ...
+export function getSerialFraming(connection: IRTUConnection): string {
+  const parity = connection.parity ?? DEFAULT_SERIAL_PARITY
+  return (
+    (connection.dataBits ?? DEFAULT_SERIAL_DATABITS).toString() +
+    parity.charAt(0).toUpperCase() +
+    (connection.stopBits ?? DEFAULT_SERIAL_STOPBITS).toString()
+  )
+}
 export function getConnectionName(connection: IModbusConnection): string {
   if ((connection as IRTUConnection).baudrate) {
     const c = connection as IRTUConnection
-    return 'RTU: ' + c.serialport + '(' + c.baudrate + ') t: ' + c.timeout
+    return 'RTU: ' + c.serialport + '(' + c.baudrate + ' ' + getSerialFraming(c) + ') t: ' + c.timeout
   } else {
     const c = connection as ITCPConnection
     return 'TCP: ' + c.host + ':' + c.port + ' t: ' + (c.timeout ? c.timeout : 100)

--- a/backend/src/types/modbus-serial.d.ts
+++ b/backend/src/types/modbus-serial.d.ts
@@ -6,7 +6,11 @@ declare module 'modbus-serial' {
     setID(id: number): void
     setTimeout(ms: number): void
     close(cb: () => void): void
-    connectRTUBuffered(path: string, opts: { baudRate: number }): Promise<void>
+    // dataBits/parity/stopBits are passed straight to serialport; omitting them means 8N1.
+    connectRTUBuffered(
+      path: string,
+      opts: { baudRate: number; dataBits?: 7 | 8; parity?: 'none' | 'even' | 'odd'; stopBits?: 1 | 2 }
+    ): Promise<void>
     connectTCP(host: string, opts: { port: number }): Promise<void>
     readHoldingRegisters(address: number, length: number): Promise<ReadRegisterResult>
     readInputRegisters(address: number, length: number): Promise<ReadRegisterResult>

--- a/backend/tests/server/modbusAPI_test.tsx
+++ b/backend/tests/server/modbusAPI_test.tsx
@@ -13,7 +13,7 @@ import {
   LogLevelEnum,
 } from '../../src/specification/index.js'
 import { ModbusAPI } from '../../src/server/modbusAPI.js'
-import { MAX_REGISTERS_PER_REQUEST_DEFAULT, ModbusTasks } from '../../src/shared/server/index.js'
+import { MAX_REGISTERS_PER_REQUEST_DEFAULT, ModbusTasks, IRTUConnection, getConnectionName } from '../../src/shared/server/index.js'
 import { TempConfigDirHelper, getAvailablePort } from './testhelper.js'
 
 const debug = Debug('bustest')
@@ -234,4 +234,49 @@ describe('ServerTCP based', () => {
   })
 
   // no-op
+})
+
+// Issue #78: the serial framing was hard wired to 8N1. The modbus specification asks for even parity
+// (8E1), and devices that insist on it - or on 8N2 - answered with nothing but timeouts.
+describe('serial framing', () => {
+  function connectOptionsFor(connection: Partial<IRTUConnection>): Record<string, unknown> {
+    const modbusAPI = new ModbusAPI({
+      getId: () => 0,
+      getName: () => 'framing',
+      getSlaveTimeoutBySlaveId: () => 100,
+      getMaxRegistersPerRequestBySlaveId: () => 125,
+      getModbusConnection: () => ({ serialport: '/dev/ttyUSB0', baudrate: 9600, timeout: 100, ...connection }) as IRTUConnection,
+    })
+    let opts: Record<string, unknown> = {}
+    modbusAPI['modbusClient'] = {
+      isOpen: false,
+      connectRTUBuffered: (_path: string, o: Record<string, unknown>) => {
+        opts = o
+        return Promise.resolve()
+      },
+    } as any
+    modbusAPI['connectRTUClientLocked']()
+    return opts
+  }
+
+  it('defaults to 8N1 when nothing is configured', () => {
+    expect(connectOptionsFor({})).toEqual({ baudRate: 9600, dataBits: 8, parity: 'none', stopBits: 1 })
+  })
+
+  it('passes the configured framing to the serial port', () => {
+    expect(connectOptionsFor({ dataBits: 8, parity: 'even', stopBits: 1 })).toEqual({
+      baudRate: 9600,
+      dataBits: 8,
+      parity: 'even',
+      stopBits: 1,
+    })
+    expect(connectOptionsFor({ stopBits: 2 })).toEqual({ baudRate: 9600, dataBits: 8, parity: 'none', stopBits: 2 })
+  })
+
+  it('shows the framing in the bus name', () => {
+    expect(getConnectionName({ serialport: '/dev/ttyUSB0', baudrate: 9600, timeout: 100 })).toContain('9600 8N1')
+    expect(
+      getConnectionName({ serialport: '/dev/ttyUSB0', baudrate: 9600, timeout: 100, parity: 'even' } as IRTUConnection)
+    ).toContain('9600 8E1')
+  })
 })

--- a/frontend/src/app/select-modbus/select-modbus.component.html
+++ b/frontend/src/app/select-modbus/select-modbus.component.html
@@ -104,6 +104,44 @@
                   </div>
                   <div>
                     <mat-form-field>
+                      <mat-label>Data Bits</mat-label>
+                      <mat-select
+                        matInput
+                        formControlName="dataBits"
+                        matTooltip="Serial framing. Together with parity and stop bits this is the '8N1' of the device's manual. Change it only if the device asks for it."
+                      >
+                        @for (dataBits of dataBitsOptions; track $index) {
+                          <mat-option [value]="dataBits">{{ dataBits }}</mat-option>
+                        }
+                      </mat-select>
+                    </mat-form-field>
+                  </div>
+                  <div>
+                    <mat-form-field>
+                      <mat-label>Parity</mat-label>
+                      <mat-select
+                        matInput
+                        formControlName="parity"
+                        matTooltip="The Modbus specification asks for even parity (8E1), but most devices ship with none (8N1). Use what the device's manual says."
+                      >
+                        @for (parity of parityOptions; track parity.value) {
+                          <mat-option [value]="parity.value">{{ parity.label }}</mat-option>
+                        }
+                      </mat-select>
+                    </mat-form-field>
+                  </div>
+                  <div>
+                    <mat-form-field>
+                      <mat-label>Stop Bits</mat-label>
+                      <mat-select matInput formControlName="stopBits">
+                        @for (stopBits of stopBitsOptions; track $index) {
+                          <mat-option [value]="stopBits">{{ stopBits }}</mat-option>
+                        }
+                      </mat-select>
+                    </mat-form-field>
+                  </div>
+                  <div>
+                    <mat-form-field>
                       <mat-label>Timeout</mat-label>
                       <input type="number" matInput formControlName="timeout" />
                     </mat-form-field>

--- a/frontend/src/app/select-modbus/select-modbus.component.ts
+++ b/frontend/src/app/select-modbus/select-modbus.component.ts
@@ -15,7 +15,18 @@ import { Clipboard } from '@angular/cdk/clipboard'
 import { MatSelectionList } from '@angular/material/list'
 import { ApiService } from '../services/api-service'
 import { MatTableDataSource } from '@angular/material/table'
-import { IBus, IModbusConnection, IRTUConnection, ITCPConnection, getBusName, getConnectionName } from '@shared/server'
+import {
+  IBus,
+  IModbusConnection,
+  IRTUConnection,
+  ITCPConnection,
+  SerialParity,
+  DEFAULT_SERIAL_DATABITS,
+  DEFAULT_SERIAL_PARITY,
+  DEFAULT_SERIAL_STOPBITS,
+  getBusName,
+  getConnectionName,
+} from '@shared/server'
 import { MatSelectChange, MatSelect } from '@angular/material/select'
 import { ActivatedRoute, Router } from '@angular/router'
 import { Observable, Subscription } from 'rxjs'
@@ -77,6 +88,15 @@ export class SelectModbusComponent implements AfterViewInit, OnDestroy {
   busses: MatTableDataSource<IBus> = new MatTableDataSource<IBus>([])
   bussesObservable: Observable<IBus[]>
   baudRates: Array<number> = [2400, 4800, 9600, 11200, 115700]
+  // Modbus RTU framing. 8N1 is what most devices ship with, but the specification asks for even
+  // parity, and a device that insists on 8E1 or 8N2 could not be reached before these existed.
+  dataBitsOptions: Array<number> = [7, 8]
+  parityOptions: Array<{ value: SerialParity; label: string }> = [
+    { value: 'none', label: 'None (N)' },
+    { value: 'even', label: 'Even (E)' },
+    { value: 'odd', label: 'Odd (O)' },
+  ]
+  stopBitsOptions: Array<number> = [1, 2]
   selectedBaudRate: number | undefined = undefined
   @ViewChild('selectBaudRate') selectBaudRate: MatSelectionList | undefined
   @Input() preselectedBusId: number | undefined = undefined
@@ -150,6 +170,12 @@ export class SelectModbusComponent implements AfterViewInit, OnDestroy {
         if (to) to.setValue(timeout)
         const tbp = fg.get(['rtu', 'tcpBridgePort'])
         if (tbp) tbp.setValue(tcpBridgePort ?? null)
+        const db = fg.get(['rtu', 'dataBits'])
+        if (db) db.setValue((bus.connectionData as IRTUConnection).dataBits ?? DEFAULT_SERIAL_DATABITS)
+        const pa = fg.get(['rtu', 'parity'])
+        if (pa) pa.setValue((bus.connectionData as IRTUConnection).parity ?? DEFAULT_SERIAL_PARITY)
+        const sb = fg.get(['rtu', 'stopBits'])
+        if (sb) sb.setValue((bus.connectionData as IRTUConnection).stopBits ?? DEFAULT_SERIAL_STOPBITS)
       } else {
         const host = (bus.connectionData as ITCPConnection).host
         const port = (bus.connectionData as ITCPConnection).port
@@ -214,6 +240,12 @@ export class SelectModbusComponent implements AfterViewInit, OnDestroy {
           ;(connectionData as IRTUConnection).serialport = serial.value
           ;(connectionData as IRTUConnection).timeout = timeout.value
         }
+        const dataBits = fg.get(['rtu', 'dataBits']) as FormControl
+        const parity = fg.get(['rtu', 'parity']) as FormControl
+        const stopBits = fg.get(['rtu', 'stopBits']) as FormControl
+        if (dataBits) (connectionData as IRTUConnection).dataBits = Number(dataBits.value)
+        if (parity) (connectionData as IRTUConnection).parity = parity.value
+        if (stopBits) (connectionData as IRTUConnection).stopBits = Number(stopBits.value)
         // Optional BridgePort
         const tcpBridgePort = fg.get(['rtu', 'tcpBridgePort']) as FormControl
         if (tcpBridgePort) {
@@ -287,6 +319,9 @@ export class SelectModbusComponent implements AfterViewInit, OnDestroy {
       rtu: this._formBuilder.group({
         serial: [null, this.serialValidator],
         selectBaudRate: [9600, Validators.required],
+        dataBits: [DEFAULT_SERIAL_DATABITS, Validators.required],
+        parity: [DEFAULT_SERIAL_PARITY, Validators.required],
+        stopBits: [DEFAULT_SERIAL_STOPBITS, Validators.required],
         timeout: [BUS_TIMEOUT_DEFAULT, Validators.required],
         tcpBridgePort: [null],
       }),

--- a/frontend/src/app/specification/entity/entity.component.ts
+++ b/frontend/src/app/specification/entity/entity.component.ts
@@ -171,16 +171,18 @@ export class EntityComponent extends SessionStorage implements AfterViewInit, On
   numberPropertiesFormGroup: FormGroup
   stringPropertiesFormGroup: FormGroup
   valuePropertiesFormGroup: FormGroup
+  // The names every datasheet and every modbus tool uses, with the function code that reads them.
+  // AnalogInputs is what the code calls them; in the modbus world they are Input Registers (FC 4).
   registerTypes: IRegisterType[] = [
     {
       registerType: ModbusRegisterType.HoldingRegister,
-      name: 'Holding Registers',
+      name: 'Holding Registers (FC 3)',
     },
-    { registerType: ModbusRegisterType.AnalogInputs, name: 'Analog Input' },
-    { registerType: ModbusRegisterType.Coils, name: 'Coils' },
+    { registerType: ModbusRegisterType.AnalogInputs, name: 'Input Registers (FC 4)' },
+    { registerType: ModbusRegisterType.Coils, name: 'Coils (FC 1)' },
     {
       registerType: ModbusRegisterType.DiscreteInputs,
-      name: 'Discrete Inputs',
+      name: 'Discrete Inputs (FC 2)',
     },
   ]
 


### PR DESCRIPTION
From #78. Two of the points raised there are still open; this fixes the one that actually blocks devices.

## Serial framing was hard wired to 8N1

`connectRTUBuffered()` was called with the baud rate and nothing else, so every RTU bus ran 8N1. The Modbus specification asks for **even parity (8E1)**, and there are plenty of devices — energy meters, several inverters — that speak only 8E1 or 8N2. On those, modbus2mqtt produced nothing but timeouts and CRC errors, with no hint in the UI as to why.

- `IRTUConnection` gets optional `dataBits` / `parity` / `stopBits`, passed straight through to serialport.
- Defaults stay **8N1**, so nothing changes for any existing bus.
- Three selects in the bus settings, next to the baud rate.
- The bus name now shows the framing: `RTU: /dev/ttyUSB0(9600 8E1) t: 1000`. Without it there is no way to tell what a bus is actually running on.

## Register types use the names from the datasheets

The entity form called FC 4 registers "Analog Input". In the modbus world — and in every datasheet and every tool — they are **Input Registers**. The list now reads:

| before | now |
| --- | --- |
| Holding Registers | Holding Registers (FC 3) |
| Analog Input | Input Registers (FC 4) |
| Coils | Coils (FC 1) |
| Discrete Inputs | Discrete Inputs (FC 2) |

Display only — `ModbusRegisterType` is untouched. The function code is still derived from register type + readonly, as designed; showing it just makes the mapping obvious to someone holding a manual.

## Tests

470 backend tests green. New: the framing defaults to 8N1 when unset, a configured framing reaches the serial port, and the bus name renders 8N1 / 8E1.

## Not in this PR (from #78)

- **Editable slave id** — deliberately left alone: the slave id is part of the Home Assistant unique id, changing it means deleting and republishing the discovery, and slave references now make re-creating a slave cheap.
- **Retained state topics** — worth doing (after a HA restart every entity sits at "unknown" until the next poll), but it is its own change. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)