### PR TITLE
fix: a slave that cannot be polled says so in Status & Errors

### DIFF
--- a/backend/src/server/mqttpoller.ts
+++ b/backend/src/server/mqttpoller.ts
@@ -12,6 +12,9 @@ import { countSlaveRequest, recordSlaveError } from './slaveStatus.js'
 
 const debug = Debug('mqttpoller')
 const defaultPollCount = 50 // 5 seconds
+// A configuration problem keeps a slave mute until someone fixes it, so it is re-recorded at this
+// interval: the error list drops entries older than an hour.
+const configErrorReportInterval = 15 * 60 * 1000 // 15 minutes
 const log = new Logger('mqttpoller')
 interface IslavePollInfo {
   count: number
@@ -24,6 +27,10 @@ export class MqttPoller {
   private slavePollInfo: Map<number, IslavePollInfo> = new Map<number, IslavePollInfo>()
   private warnedNoSpecSlaves: Set<number> = new Set<number>()
   private warnedBadCron: Set<number> = new Set<number>()
+  // When the last "this slave cannot be polled" was recorded, per slave. A configuration problem
+  // does not fix itself, so it is re-recorded regularly: the error list drops entries after an hour,
+  // and a slave that has been mute for a day should still say so.
+  private lastConfigErrorReport: Map<number, number> = new Map<number, number>()
 
   constructor(private connector: MqttConnector) {}
 
@@ -52,7 +59,7 @@ export class MqttPoller {
           if (schedule != undefined && schedule.trim().length > 0) {
             // An invalid expression is logged once and the slave is NOT polled (rather than falling
             // back to the short default interval, which would e.g. spam an HTTP push endpoint).
-            const cron = this.getCronSchedule(schedule, sl.getSlaveId())
+            const cron = this.getCronSchedule(schedule, sl)
             if (cron) {
               const minute = Math.floor(now.getTime() / 60000)
               triggerNow = pc.lastFiredMinute !== minute && cron.matches(now)
@@ -70,13 +77,11 @@ export class MqttPoller {
               pc.processing = true
               needPolls.push(s)
             } else {
-              if (slave.specificationid && !this.warnedNoSpecSlaves.has(s.getSlaveId())) {
-                log.log(
-                  LogLevelEnum.error,
-                  'No specification found for slave ' + s.getSlaveId() + ' specid: ' + s.getSpecificationId()
-                )
-                this.warnedNoSpecSlaves.add(s.getSlaveId())
-              }
+              // The slave cannot be polled: either it has no specification at all, or its
+              // specification failed to load (a broken yaml is logged once at startup and skipped).
+              // Either way the slave silently stops publishing - which used to be visible in a single
+              // log line only. Record it, so its card says why it went quiet.
+              this.reportNotPollable(s, slave.specificationid)
             }
           }
           this.slavePollInfo.set(sl.getSlaveId(), pc)
@@ -187,19 +192,49 @@ export class MqttPoller {
     })
   }
 
+  // A slave whose specification is missing or unloadable is never published. The log says so once at
+  // startup; this puts it into the slave's Status & Errors, where someone looking for the missing
+  // values will actually find it.
+  private reportNotPollable(slave: Slave, specificationid: string | undefined): void {
+    const slaveid = slave.getSlaveId()
+    const message =
+      specificationid != undefined
+        ? 'Specification "' + specificationid + '" could not be loaded. The slave is not polled.'
+        : 'No specification assigned. The slave is not polled.'
+    if (specificationid != undefined && !this.warnedNoSpecSlaves.has(slaveid)) {
+      log.log(LogLevelEnum.error, 'No specification found for slave ' + slaveid + ' specid: ' + specificationid)
+      this.warnedNoSpecSlaves.add(slaveid)
+    }
+    this.reportConfigError(slave, message)
+  }
+
+  // Throttled: the poll ticks every 100ms, and an unpollable slave would otherwise flood its own
+  // error list and push the real modbus errors out of it.
+  private reportConfigError(slave: Slave, message: string): void {
+    const slaveid = slave.getSlaveId()
+    const last = this.lastConfigErrorReport.get(slaveid)
+    const now = Date.now()
+    if (last != undefined && now - last < configErrorReportInterval) return
+    this.lastConfigErrorReport.set(slaveid, now)
+    recordSlaveError(slave, ModbusTasks.poll, ModbusErrorStates.configuration, message)
+  }
+
   // Parses a slave's cron expression, or returns undefined when it is invalid (logged once per
   // slave). The caller skips polling on undefined so a typo does not trigger unintended polls.
-  private getCronSchedule(expression: string, slaveId: number): CronSchedule | undefined {
+  private getCronSchedule(expression: string, slave: Slave): CronSchedule | undefined {
+    const slaveId = slave.getSlaveId()
     try {
       const cron = CronSchedule.parse(expression)
       this.warnedBadCron.delete(slaveId)
       return cron
     } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
       if (!this.warnedBadCron.has(slaveId)) {
-        const msg = e instanceof Error ? e.message : String(e)
         log.log(LogLevelEnum.error, 'Invalid pollSchedule for slave ' + slaveId + ', skipping poll: ' + msg)
         this.warnedBadCron.add(slaveId)
       }
+      // Same as a missing specification: the slave is never polled and would go quiet without a word.
+      this.reportConfigError(slave, 'Invalid poll schedule "' + expression + '": ' + msg + '. The slave is not polled.')
       return undefined
     }
   }

--- a/backend/tests/server/mqttpoller_test.tsx
+++ b/backend/tests/server/mqttpoller_test.tsx
@@ -4,7 +4,7 @@ import { MqttClient } from 'mqtt'
 import { FakeModes, FakeMqtt, initBussesForTest, setConfigsDirsForTest } from './configsbase.js'
 import { Bus } from '../../src/server/bus.js'
 import { expect, test, beforeAll, afterAll } from 'vitest'
-import { Slave, PollModes } from '../../src/shared/server/index.js'
+import { Slave, PollModes, ModbusTasks, ModbusErrorStates } from '../../src/shared/server/index.js'
 import { ConfigBus } from '../../src/server/configbus.js'
 import { MqttConnector } from '../../src/server/mqttconnector.js'
 import { MqttPoller } from '../../src/server/mqttpoller.js'
@@ -204,4 +204,70 @@ test('poll counter resets at threshold and allows re-polling', async () => {
   expect(pollInfo2).toBeDefined()
   expect(pollInfo2!.count).toBeGreaterThan(0)
   expect(pollInfo2!.count).toBeLessThan(50)
+})
+
+// A slave that cannot be polled - no specification, an unloadable one (issue #237: a broken
+// modbus2mqtt.yaml is logged once at startup and skipped), or an invalid cron - silently stops
+// publishing. That used to be visible in a single log line; it now shows up in the slave's card.
+function collectSlaveErrors(): { errors: { task: ModbusTasks; state: ModbusErrorStates; message: string }[]; restore: () => void } {
+  const errors: { task: ModbusTasks; state: ModbusErrorStates; message: string }[] = []
+  const api = Bus.getBus(0)!.getModbusAPI()
+  const original = api.addSlaveError
+  api.addSlaveError = (_slaveid: number, task: ModbusTasks, state: ModbusErrorStates, message: string) =>
+    errors.push({ task, state, message })
+  return { errors, restore: () => (api.addSlaveError = original) }
+}
+
+test('a slave whose specification cannot be loaded reports it in Status & Errors', async () => {
+  const fd = getFakeDiscovery()
+  copySubscribedSlaves(fd.msub['subscribedSlaves'], fakeDiscovery.msub['subscribedSlaves'])
+
+  const target = Bus.getBus(0)!
+    .getSlaves()
+    .find((s) => s.pollMode != undefined && ![PollModes.noPoll, PollModes.trigger].includes(s.pollMode) && s.specification)
+  expect(target).toBeDefined()
+  const savedSpec = target!.specification
+  delete target!.specification // what a failed spec load leaves behind
+  const collected = collectSlaveErrors()
+
+  try {
+    await fd.mdl['poll']!(Bus.getBus(0)!)
+    expect(collected.errors.length).toBe(1)
+    expect(collected.errors[0].task).toBe(ModbusTasks.poll)
+    expect(collected.errors[0].state).toBe(ModbusErrorStates.configuration)
+    expect(collected.errors[0].message).toContain('could not be loaded')
+    expect(collected.errors[0].message).toContain('not polled')
+
+    // the poll ticks 10x a second - the error list must not be flooded with the same message
+    await fd.mdl['poll']!(Bus.getBus(0)!)
+    await fd.mdl['poll']!(Bus.getBus(0)!)
+    expect(collected.errors.length).toBe(1)
+  } finally {
+    collected.restore()
+    target!.specification = savedSpec
+  }
+})
+
+test('an invalid poll schedule reports it in Status & Errors', async () => {
+  const fd = getFakeDiscovery()
+  copySubscribedSlaves(fd.msub['subscribedSlaves'], fakeDiscovery.msub['subscribedSlaves'])
+
+  const target = Bus.getBus(0)!
+    .getSlaves()
+    .find((s) => s.pollMode != undefined && ![PollModes.noPoll, PollModes.trigger].includes(s.pollMode) && s.specification)
+  expect(target).toBeDefined()
+  const saved = target!.pollSchedule
+  target!.pollSchedule = 'not a cron'
+  const collected = collectSlaveErrors()
+
+  try {
+    await fd.mdl['poll']!(Bus.getBus(0)!)
+    expect(collected.errors.length).toBe(1)
+    expect(collected.errors[0].state).toBe(ModbusErrorStates.configuration)
+    expect(collected.errors[0].message).toContain('Invalid poll schedule')
+  } finally {
+    collected.restore()
+    if (saved == undefined) delete target!.pollSchedule
+    else target!.pollSchedule = saved
+  }
 })


### PR DESCRIPTION
Follow-up to #237, and the last piece of the Status & Errors work (#288).

## The problem

A slave whose specification fails to load goes quiet without a word:

1. `specPersistence` catches the parse error, logs **one** line — `Unable to load spec modbus2mqtt.yaml continuing Cannot read properties of undefined (reading 'forEach')` — and skips the file.
2. The slave ends up with no specification.
3. `mqttpoller` skips such a slave (it warns once, then never again).

Modbus keeps being read, so from the outside everything looks alive. The only trace is that single startup line, long scrolled out of the log by the time someone notices the missing values in Home Assistant. That is exactly the situation in #237.

An **invalid cron schedule** leaves a slave equally mute: `getCronSchedule()` returns undefined, the slave is deliberately not polled (falling back to the default interval would e.g. spam an HTTP push endpoint), and nothing says so.

## The change

Both cases are recorded as a `configuration` error on the slave, so its card answers the question someone is actually asking — *why did this slave stop delivering?*

- `Specification "x" could not be loaded. The slave is not polled.`
- `No specification assigned. The slave is not polled.`
- `Invalid poll schedule "not a cron": ... The slave is not polled.`

Throttled to once per 15 minutes per slave: the poll ticks ten times a second, so an unpollable slave would otherwise flood its own error list (capped at 50 entries) and push the real modbus errors out of it. Fifteen minutes is also short enough to survive the one-hour cleanup of the error list — a configuration problem does not fix itself, and a slave that has been mute for a day should still say so.

## Tests

480 backend tests green. New: the unloadable-specification case is recorded once (and not re-recorded on the next two ticks), and the invalid cron case is recorded too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)