### PR TITLE
fix(ui): show the failing url in Status & Errors, reject a blank in the push url

### DIFF
--- a/backend/src/server/httpPush.ts
+++ b/backend/src/server/httpPush.ts
@@ -7,6 +7,7 @@ import { countSlaveRequest, recordSlaveError } from './slaveStatus.js'
 
 const debug = Debug('httppush')
 const log = new Logger('httppush')
+const maxReasonLength = 200
 
 export class HttpPush {
   // Pushes the slave's selected entity values to the configured URL via HTTP POST.
@@ -34,12 +35,29 @@ export class HttpPush {
       }
       debug('HTTP push to ' + url + ' body: ' + body)
       const resp = await fetch(url, { method: 'POST', headers, body })
-      if (!resp.ok) this.fail(slave, ModbusErrorStates.httpStatus, resp.status + ' ' + resp.statusText, url)
-      else countSlaveRequest(slave, ModbusTasks.httpPush)
+      if (!resp.ok) {
+        // An endpoint that rejects a push almost always says why in its response body ("missing
+        // field", "unknown id"). Throwing that away left the user with a bare "400 Bad Request".
+        const reason = await this.readReason(resp)
+        this.fail(slave, ModbusErrorStates.httpStatus, resp.status + ' ' + resp.statusText, url + (reason ? ' -> ' + reason : ''))
+      } else countSlaveRequest(slave, ModbusTasks.httpPush)
     } catch (e: unknown) {
       // fetch() rejects when the endpoint is unreachable (DNS, refused, TLS, abort)
       const msg = e instanceof Error ? e.message : String(e)
       this.fail(slave, ModbusErrorStates.connection, msg, url ?? httpPush.url)
+    }
+  }
+
+  // The endpoint's own explanation of the rejection, shortened. Reading it must never turn a failed
+  // push into a crash, and it must not paste a whole error page into the log, so it is guarded and
+  // truncated.
+  private static async readReason(resp: Response): Promise<string> {
+    try {
+      const text = (await resp.text()).trim().replace(/\s+/g, ' ')
+      if (text.length == 0) return ''
+      return text.length > maxReasonLength ? text.substring(0, maxReasonLength) + '…' : text
+    } catch {
+      return ''
     }
   }
 

--- a/backend/src/server/httpPush.ts
+++ b/backend/src/server/httpPush.ts
@@ -43,9 +43,10 @@ export class HttpPush {
     }
   }
 
-  // Logs the url the push was actually sent to (placeholders resolved) - the template is of no use
-  // when diagnosing a failing request. The recorded error keeps the plain message: a resolved url
-  // may contain the poll time, which would make every single failure a group of its own in the UI.
+  // The url the push was actually sent to (placeholders resolved) - the template is of no use when
+  // diagnosing a failing request, and the add-on log has usually scrolled past it by the time anyone
+  // looks. It travels as the error's detail, not in its message: a resolved url may carry the poll
+  // time, and the UI groups the errors by message.
   private static fail(
     slave: Slave,
     state: ModbusErrorStates,
@@ -54,6 +55,6 @@ export class HttpPush {
     level: LogLevelEnum = LogLevelEnum.error
   ): void {
     log.log(level, 'HTTP push failed: ' + message + ' url: ' + url)
-    recordSlaveError(slave, ModbusTasks.httpPush, state, message)
+    recordSlaveError(slave, ModbusTasks.httpPush, state, message, url)
   }
 }

--- a/backend/src/server/httpPush.ts
+++ b/backend/src/server/httpPush.ts
@@ -29,6 +29,13 @@ export class HttpPush {
         this.fail(slave, ModbusErrorStates.configuration, 'root path "' + httpPush.root + '" not found', url, LogLevelEnum.warn)
         return
       }
+      // An empty payload means no entity is selected under "Select entities to push". Posting "{}"
+      // is never what anyone wants - the endpoint rejects it (400) or, worse, stores nothing and says
+      // OK. Report it as the configuration mistake it is instead of sending it.
+      if (body == '{}' || body == '[]') {
+        this.fail(slave, ModbusErrorStates.configuration, 'No entities selected to push - nothing to send', url, LogLevelEnum.warn)
+        return
+      }
       const headers: Record<string, string> = { 'Content-Type': 'application/json' }
       if (httpPush.patEnc && httpPush.patEnc.length > 0) {
         headers['Authorization'] = 'Bearer ' + decryptSecret(httpPush.patEnc)

--- a/backend/src/server/modbusAPI.ts
+++ b/backend/src/server/modbusAPI.ts
@@ -43,7 +43,7 @@ export interface IconsumerModbusAPI {
     options: IQueueOptions
   ) => Promise<void>
   readModbusRegister: (slaveId: number, addresses: Set<ImodbusAddress>, options: IexecuteOptions) => Promise<ImodbusValues>
-  addSlaveError: (slaveid: number, task: ModbusTasks, state: ModbusErrorStates, message: string) => void
+  addSlaveError: (slaveid: number, task: ModbusTasks, state: ModbusErrorStates, message: string, detail?: string) => void
   countRequest: (slaveid: number, task: ModbusTasks) => void
 }
 export interface IModbusConfiguration {
@@ -390,8 +390,8 @@ export class ModbusAPI implements IModbusAPI, IconsumerModbusAPI {
   }
   // Entry point for the non modbus tasks (mqtt publish, http push) to report into the slave's
   // error list, so the UI shows all failures of a poll cycle in one place.
-  addSlaveError(slaveid: number, task: ModbusTasks, state: ModbusErrorStates, message: string): void {
-    this._modbusRTUWorker.addSlaveError(slaveid, task, state, message)
+  addSlaveError(slaveid: number, task: ModbusTasks, state: ModbusErrorStates, message: string, detail?: string): void {
+    this._modbusRTUWorker.addSlaveError(slaveid, task, state, message, detail)
   }
   countRequest(slaveid: number, task: ModbusTasks): void {
     this._modbusRTUWorker.countRequest(slaveid, task)

--- a/backend/src/server/modbusRTUworker.ts
+++ b/backend/src/server/modbusRTUworker.ts
@@ -409,8 +409,15 @@ export class ModbusRTUWorker extends ModbusWorker {
   // Records a failure of a task which doesn't talk modbus (mqttPublish, httpPush). It has no
   // register address, the message describes the failure instead. Shares the slave's error list,
   // so a poll cycle failing at any stage shows up in the slave's Status & Errors panel.
-  public addSlaveError(slaveId: number, task: ModbusTasks, state: ModbusErrorStates, message: string, date: Date = new Date()) {
-    this.pushError(slaveId, new ModbusErrorDescription({ task, state, message }, date))
+  public addSlaveError(
+    slaveId: number,
+    task: ModbusTasks,
+    state: ModbusErrorStates,
+    message: string,
+    detail?: string,
+    date: Date = new Date()
+  ) {
+    this.pushError(slaveId, new ModbusErrorDescription({ task, state, message, detail }, date))
   }
   // Counts a successfully processed call of a non modbus task. The modbus tasks are counted in
   // processOneEntry(); without this the UI would report "0 processed calls" for mqtt and http push.

--- a/backend/src/server/mqttpoller.ts
+++ b/backend/src/server/mqttpoller.ts
@@ -158,7 +158,8 @@ export class MqttPoller {
                               entry.slave,
                               ModbusTasks.mqttPublish,
                               ModbusErrorStates.connection,
-                              err.message + ' topic: ' + entry.message.topic
+                              err.message,
+                              'topic: ' + entry.message.topic
                             )
                           else countSlaveRequest(entry.slave, ModbusTasks.mqttPublish)
                         })

--- a/backend/src/server/mqttsubscriptions.ts
+++ b/backend/src/server/mqttsubscriptions.ts
@@ -150,7 +150,7 @@ export class MqttSubscriptions {
       // HttpPush records its own errors, so anything arriving here failed to publish to mqtt.
       const msg = e instanceof Error ? e.message : String(e)
       log.log(LogLevelEnum.error, 'publishState failed: ' + msg)
-      recordSlaveError(slave, ModbusTasks.mqttPublish, ModbusErrorStates.connection, msg + ' topic: ' + topic)
+      recordSlaveError(slave, ModbusTasks.mqttPublish, ModbusErrorStates.connection, msg, 'topic: ' + topic)
       try {
         await this.publishAsync(mqttClient, slave.getAvailabilityTopic(), 'offline', options)
       } catch (e2: unknown) {

--- a/backend/src/server/slaveStatus.ts
+++ b/backend/src/server/slaveStatus.ts
@@ -6,8 +6,16 @@ import { Bus } from './bus.js'
 // the UI as Islave.modbusStatusForSlave. These helpers let the tasks which don't talk modbus - mqtt
 // publish and http push - report into the same list, so the Status & Errors panel of a slave shows
 // every failure of a poll cycle, not just the modbus part of it.
-export function recordSlaveError(slave: Slave, task: ModbusTasks, state: ModbusErrorStates, message: string): void {
-  Bus.getBus(slave.getBusId())?.getModbusAPI()?.addSlaveError(slave.getSlaveId(), task, state, message)
+// detail carries what is needed to act on the failure but is too volatile to group by - the resolved
+// push url, the topic of a failed publish. The UI groups by message and shows the newest detail.
+export function recordSlaveError(
+  slave: Slave,
+  task: ModbusTasks,
+  state: ModbusErrorStates,
+  message: string,
+  detail?: string
+): void {
+  Bus.getBus(slave.getBusId())?.getModbusAPI()?.addSlaveError(slave.getSlaveId(), task, state, message, detail)
 }
 
 export function countSlaveRequest(slave: Slave, task: ModbusTasks): void {

--- a/backend/src/shared/server/types.ts
+++ b/backend/src/shared/server/types.ts
@@ -182,6 +182,10 @@ export interface ImodbusErrorsForSlave {
   address?: ImodbusAddress
   state: ModbusErrorStates
   message?: string
+  // Everything needed to act on the failure but too volatile to group by: the resolved push url of
+  // an http push (it may carry the poll time), the topic of a failed publish. The UI groups the
+  // errors by message and shows the detail of the most recent one.
+  detail?: string
 }
 export interface ImodbusStatusForSlave {
   requestCount: number[]

--- a/backend/tests/server/httppush_test.tsx
+++ b/backend/tests/server/httppush_test.tsx
@@ -411,7 +411,7 @@ describe('HttpPush.pushState (poll process)', () => {
 // A failed push must show up in the slave's Status & Errors panel next to the modbus errors.
 describe('HttpPush.pushState error reporting', () => {
   let originalFetch: typeof globalThis.fetch
-  let errors: { task: ModbusTasks; state: ModbusErrorStates; message: string }[]
+  let errors: { task: ModbusTasks; state: ModbusErrorStates; message: string; detail?: string }[]
   let counted: ModbusTasks[]
   let getBusSpy: ReturnType<typeof jest.spyOn>
 
@@ -431,20 +431,67 @@ describe('HttpPush.pushState error reporting', () => {
     errors = []
     counted = []
     const modbusAPI = {
-      addSlaveError: (_slaveid: number, task: ModbusTasks, state: ModbusErrorStates, message: string) =>
-        errors.push({ task, state, message }),
+      addSlaveError: (_slaveid: number, task: ModbusTasks, state: ModbusErrorStates, message: string, detail?: string) =>
+        errors.push(detail != undefined ? { task, state, message, detail } : { task, state, message }),
       countRequest: (_slaveid: number, task: ModbusTasks) => counted.push(task),
     }
     getBusSpy = jest.spyOn(Bus, 'getBus').mockReturnValue({ getModbusAPI: () => modbusAPI } as any)
   })
 
   it('records a non 2xx response as httpStatus error', async () => {
-    globalThis.fetch = jest.fn(async () => ({ ok: false, status: 503, statusText: 'Service Unavailable' }) as any) as any
+    globalThis.fetch = jest.fn(
+      async () => ({ ok: false, status: 503, statusText: 'Service Unavailable', text: async () => '' }) as any
+    ) as any
     await HttpPush.pushState(slave, spec)
     expect(errors).toEqual([
-      { task: ModbusTasks.httpPush, state: ModbusErrorStates.httpStatus, message: '503 Service Unavailable' },
+      {
+        task: ModbusTasks.httpPush,
+        state: ModbusErrorStates.httpStatus,
+        message: '503 Service Unavailable',
+        detail: 'https://api/x',
+      },
     ])
     expect(counted).toEqual([])
+  })
+
+  it("keeps the endpoint's own explanation of a rejection", async () => {
+    globalThis.fetch = jest.fn(
+      async () =>
+        ({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          text: async () => '{ "error": "unknown reading id 250934682" }',
+        }) as any
+    ) as any
+    await HttpPush.pushState(slave, spec)
+    // the message stays the grouping key, the reason travels with the url in the detail
+    expect(errors[0].message).toBe('400 Bad Request')
+    expect(errors[0].detail).toContain('https://api/x')
+    expect(errors[0].detail).toContain('unknown reading id 250934682')
+  })
+
+  it('shortens a long error page and survives an unreadable body', async () => {
+    globalThis.fetch = jest.fn(
+      async () => ({ ok: false, status: 400, statusText: 'Bad Request', text: async () => 'x'.repeat(500) }) as any
+    ) as any
+    await HttpPush.pushState(slave, spec)
+    expect(errors[0].detail!.length).toBeLessThan(300)
+
+    errors.length = 0
+    globalThis.fetch = jest.fn(
+      async () =>
+        ({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          text: async () => {
+            throw new Error('stream closed')
+          },
+        }) as any
+    ) as any
+    await HttpPush.pushState(slave, spec)
+    expect(errors[0].message).toBe('400 Bad Request')
   })
 
   it('records an unreachable endpoint as connection error', async () => {
@@ -452,7 +499,9 @@ describe('HttpPush.pushState error reporting', () => {
       throw new Error('fetch failed')
     }) as any
     await HttpPush.pushState(slave, spec)
-    expect(errors).toEqual([{ task: ModbusTasks.httpPush, state: ModbusErrorStates.connection, message: 'fetch failed' }])
+    expect(errors).toEqual([
+      { task: ModbusTasks.httpPush, state: ModbusErrorStates.connection, message: 'fetch failed', detail: 'https://api/x' },
+    ])
   })
 
   it('records an unresolvable URL placeholder as configuration error', async () => {

--- a/backend/tests/server/httppush_test.tsx
+++ b/backend/tests/server/httppush_test.tsx
@@ -512,8 +512,17 @@ describe('HttpPush.pushState error reporting', () => {
     expect(globalThis.fetch).not.toHaveBeenCalled()
   })
 
+  it('does not post an empty payload when no entity is selected', async () => {
+    globalThis.fetch = jest.fn(async () => ({ ok: true, status: 200, statusText: 'OK', text: async () => '' }) as any) as any
+    const noEntities = new Slave(0, { slaveid: 7, httpPush: { url: 'https://api/x', pushEntities: [] } }, 'm2m')
+    await HttpPush.pushState(noEntities, spec)
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+    expect(errors[0].state).toBe(ModbusErrorStates.configuration)
+    expect(errors[0].message).toContain('No entities selected')
+  })
+
   it('counts a successful push instead of recording an error', async () => {
-    globalThis.fetch = jest.fn(async () => ({ ok: true, status: 200, statusText: 'OK' }) as any) as any
+    globalThis.fetch = jest.fn(async () => ({ ok: true, status: 200, statusText: 'OK', text: async () => '' }) as any) as any
     await HttpPush.pushState(slave, spec)
     expect(errors).toEqual([])
     expect(counted).toEqual([ModbusTasks.httpPush])

--- a/frontend/src/app/modbus-error/modbus-error.component.css
+++ b/frontend/src/app/modbus-error/modbus-error.component.css
@@ -23,3 +23,11 @@
 .indent3 {
   text-indent: 6em;
 }
+/* A push url can be long: wrap it instead of pushing the card wider */
+.error-detail {
+  font-family: monospace;
+  font-size: 0.85em;
+  opacity: 0.8;
+  overflow-wrap: anywhere;
+  margin-top: 0.5em;
+}

--- a/frontend/src/app/modbus-error/modbus-error.component.html
+++ b/frontend/src/app/modbus-error/modbus-error.component.html
@@ -49,6 +49,11 @@
         @for (e of getErrors(errorlist); track $index) {
           <div>{{ e }}</div>
         }
+        <!-- The url a failing http push was actually sent to, the topic of a failed publish: too
+             volatile to group by, but it is what one needs to act on the failure. -->
+        @if (getLastDetail(errorlist); as detail) {
+          <div class="error-detail">{{ detail }}</div>
+        }
       </div>
     </mat-expansion-panel>
   </ng-template>

--- a/frontend/src/app/modbus-error/modbus-error.component.ts
+++ b/frontend/src/app/modbus-error/modbus-error.component.ts
@@ -190,6 +190,17 @@ export class ModbusErrorComponent implements OnInit, OnDestroy {
     messages.forEach((m) => rcs.push(m.message + ': ' + m.count))
     return rcs
   }
+  // The detail of the most recent error of the list: the url a failing http push was sent to (with
+  // its placeholders resolved), the topic of a failed publish. Only the newest one, because a detail
+  // can differ per occurrence - that is exactly why it is not part of the grouping message.
+  getLastDetail(inValue: ImodbusErrorsForSlave[]): string | null {
+    if (inValue == undefined || inValue.length == 0) return null
+    let last: ImodbusErrorsForSlave = inValue[0]
+    inValue.forEach((e) => {
+      if (e.date > last.date) last = e
+    })
+    return last.detail != undefined && last.detail.length > 0 ? last.detail : null
+  }
   getSinceTimeString(errorList: ImodbusErrorsForSlave[]): string {
     if (errorList == undefined) return 'XX'
     const delta = this.getCurrentDate() - errorList[errorList.length - 1].date

--- a/frontend/src/app/modbus-error/modbus-error.vitest.spec.ts
+++ b/frontend/src/app/modbus-error/modbus-error.vitest.spec.ts
@@ -29,8 +29,20 @@ describe('ModbusErrorComponent (vitest)', () => {
   // The transport tasks have no register address, they carry a message instead
   const buildHttpPushErrors = (): ImodbusStatusForSlave => ({
     errors: [
-      { task: ModbusTasks.httpPush, date: date, state: ModbusErrorStates.httpStatus, message: '503 Service Unavailable' },
-      { task: ModbusTasks.httpPush, date: date, state: ModbusErrorStates.httpStatus, message: '503 Service Unavailable' },
+      {
+        task: ModbusTasks.httpPush,
+        date: date - 1000,
+        state: ModbusErrorStates.httpStatus,
+        message: '503 Service Unavailable',
+        detail: 'https://api/readings/1?at=2026-07-14T04%3A46%3A00Z',
+      },
+      {
+        task: ModbusTasks.httpPush,
+        date: date,
+        state: ModbusErrorStates.httpStatus,
+        message: '503 Service Unavailable',
+        detail: 'https://api/readings/1?at=2026-07-14T04%3A47%3A00Z',
+      },
     ],
     requestCount: [0, 0, 0, 0, 0, 0, 0, 0, 0, 7],
     queueLength: 0,
@@ -82,5 +94,11 @@ describe('ModbusErrorComponent (vitest)', () => {
     expect(text).toContain('(7 processed calls)')
     expect(text).toContain('HTTP Error Status')
     expect(f.componentInstance.getErrors(buildHttpPushErrors().errors)).toEqual(['503 Service Unavailable: 2'])
+    // the url stays out of the grouping message (it carries the poll time and would split every
+    // failure into a group of its own), but the newest one is shown - that is what one acts on
+    expect(f.componentInstance.getLastDetail(buildHttpPushErrors().errors)).toBe(
+      'https://api/readings/1?at=2026-07-14T04%3A47%3A00Z'
+    )
+    expect(text).toContain('at=2026-07-14T04%3A47%3A00Z')
   })
 })

--- a/frontend/src/app/select-slave/select-slave.component.ts
+++ b/frontend/src/app/select-slave/select-slave.component.ts
@@ -181,6 +181,10 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
       })
       // Anything left over means a brace does not belong to a well formed placeholder.
       if (rest.includes('{') || rest.includes('}')) return { placeholderSyntax: true }
+      // A literal blank survives into the request line ("&c0= {{ slaveName }}" keeps the blank in
+      // front of the resolved name) and every http server answers that with 400 Bad Request. The
+      // resolved values are URL encoded, the text around them is not.
+      if (/\s/.test(rest)) return { urlWhitespace: true }
       if (names.includes('slaveName')) {
         const name = control.parent?.get('name')?.value ?? slave.name
         if (!name || String(name).length == 0) return { slaveNameEmpty: true }
@@ -209,6 +213,8 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
     if (!control || !control.errors) return null
     if (control.errors['placeholderSyntax'])
       return 'Malformed placeholder: every {{ and }} must be doubled, e.g. {{ serialnumber }}.'
+    if (control.errors['urlWhitespace'])
+      return 'The URL contains a blank. It is sent as is and the endpoint answers 400 Bad Request - remove it (e.g. "c0= {{ slaveName }}" must be "c0={{ slaveName }}").'
     if (control.errors['slaveNameEmpty']) return '{{ slaveName }} is used, but this slave has no Slave Name.'
     const unknown = control.errors['unknownPlaceholder']
     if (unknown) {

--- a/frontend/src/app/select-slave/select-slave.vitest.spec.ts
+++ b/frontend/src/app/select-slave/select-slave.vitest.spec.ts
@@ -190,6 +190,15 @@ describe('Select Slave tests (vitest)', () => {
       httpMock.match(() => true).forEach((r) => r.flush([]))
     })
 
+    it('rejects a blank in the URL', async () => {
+      await mount()
+      // exactly the typo that produced a 400 Bad Request in the field: the blank stays literal
+      const error = await validate('https://api/r?c0= {{ slaveName }}')
+      expect(error).toContain('blank')
+      expect(await validate('https://api/r?c0={{ slaveName }}')).toBeNull()
+      httpMock.match(() => true).forEach((r) => r.flush([]))
+    })
+
     it('rejects an unknown name and lists the available ones', async () => {
       await mount()
       const error = await validate('https://api/r/{{ serialnumber }}')


### PR DESCRIPTION
Straight out of debugging a failing HTTP push in the field.

## The url of a failed push was not reachable

The Status & Errors panel said `400 Bad Request` and nothing else. The resolved url is written to the log, but by the time anyone looks at a slave that stopped delivering, it has scrolled out of the add-on log. So the one thing needed to act on the failure was the one thing missing.

`ImodbusErrorsForSlave` gets an optional `detail`: what one needs to act on a failure, but too volatile to group by.

- `HttpPush` fills it with the url the push was **actually sent to** (placeholders resolved).
- A failing MQTT publish fills it with its topic.
- The errors are still **grouped by message** — a resolved url may carry the poll time (`{{ pollDate }}`), and putting it into the message would turn every single failure into a group of its own. The panel shows the detail of the **newest** error of a group, which is the one to act on.

## The url then explained the 400 immediately

```
...&c0= Strom%20OG%2FDG
        ↑ a literal blank
```

The template read `&c0= {{ slaveName }}`. The blank in front of the placeholder is plain text, so it survives into the request line unencoded — only the *resolved values* are URL encoded, the text around them is not — and a blank in the request line is a syntax error for any HTTP server: **400 Bad Request**.

The push url field now rejects a blank, with the same kind of message it already gives for a malformed placeholder:

> The URL contains a blank. It is sent as is and the endpoint answers 400 Bad Request - remove it (e.g. "c0= {{ slaveName }}" must be "c0={{ slaveName }}").

## Tests

483 backend + 32 frontend tests green. New: the detail travels through the recorder into the error list and the panel renders the newest one; the url validator rejects a blank and accepts the same url without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)